### PR TITLE
Revert invalid masonry selector to fix edge cases in Space view

### DIFF
--- a/app/views/spaces/space.scala.html
+++ b/app/views/spaces/space.scala.html
@@ -139,7 +139,7 @@
             imagesLoaded( '.tiled-image', function() {
                 match.masonry({
                     itemSelector: '.tiled-image',
-                    columnWidth: '.tiled-image',
+                    columnWidth: '.post-box',
                     transitionDuration: 4
                 });
             });


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

### Problem
The `columnWidth` property apparently tells masonry a selector that defines a single column. Setting these to the same value cause a couple of other issues. Only the `itemSelector` should have been modified.

### Approach
Revert a line from #11 that should not have been modified.

### How to Test

Setup:
1. Checkout and run this branch locally
2. Login to Clowder and create a Space
3. Add 2 datasets to this space 

#### Case A: No preview images
Prerequisites: no image previews attached to any files or dataset in the Space

1. View the Space in Clowder
    * You should see that the Dataset cards no longer overlap with the Collections section below

#### Case B: With preview images

1. Run the `image-preview` extractor and upload an image file to one or more of the datasets
    * This should attach an image preview to the dataset
2. View the Space in Clowder
    * You should see that the Dataset cards are now stacked horizontally and vertically, instead of only vertically

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [x] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation. N / A
- [ ] I have updated the CHANGELOG.md. N / A
- [ ] I have signed the CLA
- [ ] I have updated the documentation accordingly. N / A
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. N / A
- [x] All new and existing tests passed.
