### PR TITLE
Queue returns no actions if db inaccessible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: github branch
+        run: |
+          BRANCH=${GITHUB_REF##*/}
+          echo "::set-env name=GITHUB_BRANCH::${BRANCH}"
+          if [ "$BRANCH" == "master" ]; then
+            echo "::set-env name=CLOWDER_VERSION::$(awk '/version = / { print $4 }' project/Build.scala | sed 's/"//g')"
+          elif [ "$BRANCH" == "develop" ]; then
+            echo "::set-env name=CLOWDER_VERSION::develop"
+          else 
+            echo "::set-env name=CLOWDER_VERSION::testing"
+          fi
       - uses: actions/setup-java@v1
         with:
           java-version: 1.8
@@ -46,8 +57,18 @@ jobs:
           key: ${{ runner.os }}-sbt-${{ hashFiles('project/Build.scala') }}
       - name: sbt clean update
         run: ./sbt clean update
+        env:
+          BRANCH: ${{ env.GITHUB_BRANCH }}
+          VERSION: ${{ env.CLOWDER_VERSION }}
+          BUILDNUMBER: ${{ github.run_number }}
+          GITSHA1: ${{ github.sha  }}
       - name: sbt compile
         run: ./sbt compile
+        env:
+          BRANCH: ${{ env.GITHUB_BRANCH }}
+          VERSION: ${{ env.CLOWDER_VERSION }}
+          BUILDNUMBER: ${{ github.run_number }}
+          GITSHA1: ${{ github.sha  }}
 
   # starts a mongodb instance, and runs the scala tests
   test:
@@ -59,10 +80,18 @@ jobs:
         ports:
           - 27017:27017
     steps:
-      - uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
       - uses: actions/checkout@v2
+      - name: github branch
+        run: |
+          BRANCH=${GITHUB_REF##*/}
+          echo "::set-env name=GITHUB_BRANCH::${BRANCH}"
+          if [ "$BRANCH" == "master" ]; then
+            echo "::set-env name=CLOWDER_VERSION::$(awk '/version = / { print $4 }' project/Build.scala | sed 's/"//g')"
+          elif [ "$BRANCH" == "develop" ]; then
+            echo "::set-env name=CLOWDER_VERSION::develop"
+          else 
+            echo "::set-env name=CLOWDER_VERSION::testing"
+          fi
       - uses: actions/setup-java@v1
         with:
           java-version: 1.8
@@ -78,6 +107,11 @@ jobs:
           key: ${{ runner.os }}-sbt-${{ hashFiles('project/Build.scala') }}
       - name: sbt test
         run: ./sbt "test-only integration.APITestSuite"
+        env:
+          BRANCH: ${{ env.GITHUB_BRANCH }}
+          VERSION: ${{ env.CLOWDER_VERSION }}
+          BUILDNUMBER: ${{ github.run_number }}
+          GITSHA1: ${{ github.sha  }}
 
   # creates zip file of the dist compiled version. The results are
   # uploaded as artifacts for this build as well to the release if
@@ -87,6 +121,17 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@v2
+      - name: github branch
+        run: |
+          BRANCH=${GITHUB_REF##*/}
+          echo "::set-env name=GITHUB_BRANCH::${BRANCH}"
+          if [ "$BRANCH" == "master" ]; then
+            echo "::set-env name=CLOWDER_VERSION::$(awk '/version = / { print $4 }' project/Build.scala | sed 's/"//g')"
+          elif [ "$BRANCH" == "develop" ]; then
+            echo "::set-env name=CLOWDER_VERSION::develop"
+          else 
+            echo "::set-env name=CLOWDER_VERSION::testing"
+          fi
       - uses: actions/setup-java@v1
         with:
           java-version: 1.8
@@ -102,13 +147,18 @@ jobs:
           key: ${{ runner.os }}-sbt-${{ hashFiles('project/Build.scala') }}
       - name: sbt dist
         run: ./sbt dist
+        env:
+          BRANCH: ${{ env.GITHUB_BRANCH }}
+          VERSION: ${{ env.CLOWDER_VERSION }}
+          BUILDNUMBER: ${{ github.run_number }}
+          GITSHA1: ${{ github.sha  }}
       - uses: actions/upload-artifact@v2
         with:
           name: clowder.zip
           path: target/universal/clowder-*.zip
       - name: Upload files to a GitHub release
-        uses: svenstaro/upload-release-action@1.1.0
         if: github.event_name == 'release' && github.event.action == 'created'
+        uses: svenstaro/upload-release-action@1.1.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.ref }}
@@ -116,6 +166,15 @@ jobs:
           asset_name: clowder.zip
           file: target/universal/clowder-*.zip
           file_glob: true
+      - name: Upload dist to NCSA
+        if: github.event_name == 'push'
+        uses: robkooper/sftp-action@master
+        with:
+          host: ${{ secrets.SCP_HOST }}
+          username: ${{ secrets.SCP_USERNAME }}
+          key: ${{ secrets.SCP_KEY }}
+          files: "target/universal/clowder-*.zip"
+          target: "CATS/${{ env.CLOWDER_VERSION }}/files"
 
   # creates scaladoc, html and epub (no pdflatex) and uploads those
   # as artifacts for this build as well to the release if created.
@@ -124,6 +183,17 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@v2
+      - name: github branch
+        run: |
+          BRANCH=${GITHUB_REF##*/}
+          echo "::set-env name=GITHUB_BRANCH::${BRANCH}"
+          if [ "$BRANCH" == "master" ]; then
+            echo "::set-env name=CLOWDER_VERSION::$(awk '/version = / { print $4 }' project/Build.scala | sed 's/"//g')"
+          elif [ "$BRANCH" == "develop" ]; then
+            echo "::set-env name=CLOWDER_VERSION::develop"
+          else 
+            echo "::set-env name=CLOWDER_VERSION::testing"
+          fi
       - uses: actions/setup-java@v1
         with:
           java-version: 1.8
@@ -143,11 +213,25 @@ jobs:
           python-version: 3.7
       - name: sbt doc
         run: ./sbt doc
+        env:
+          BRANCH: ${{ env.GITHUB_BRANCH }}
+          VERSION: ${{ env.CLOWDER_VERSION }}
+          BUILDNUMBER: ${{ github.run_number }}
+          GITSHA1: ${{ github.sha  }}
       - uses: actions/upload-artifact@v2
         with:
           name: ScalaDoc
           path: target/scala-*/api/
-      - name: sphinx
+      - name: Upload scaladoc to NCSA
+        if: github.event_name == 'push'
+        uses: robkooper/sftp-action@master
+        with:
+          host: ${{ secrets.SCP_HOST }}
+          username: ${{ secrets.SCP_USERNAME }}
+          key: ${{ secrets.SCP_KEY }}
+          files: "target/scala-*/api/*"
+          target: "CATS/${{ env.CLOWDER_VERSION }}/documentation/scaladoc"
+      - name: sphinx  
         run: |
           cd doc/src/sphinx/
           python -m pip install -r requirements.txt
@@ -156,16 +240,34 @@ jobs:
         with:
           name: HTML Documentation
           path: doc/src/sphinx/_build/html
+      - name: Upload sphinx to NCSA
+        if: github.event_name == 'push'
+        uses: robkooper/sftp-action@master
+        with:
+          host: ${{ secrets.SCP_HOST }}
+          username: ${{ secrets.SCP_USERNAME }}
+          key: ${{ secrets.SCP_KEY }}
+          files: "doc/src/sphinx/_build/html/*"
+          target: "CATS/${{ env.CLOWDER_VERSION }}/documentation/sphinx"
       - uses: actions/upload-artifact@v2
         with:
           name: EPUB Documentation
           path: doc/src/sphinx/_build/epub/Clowder.epub
       - name: Upload files to a GitHub release
-        uses: svenstaro/upload-release-action@1.1.0
         if: github.event_name == 'release' && github.event.action == 'created'
+        uses: svenstaro/upload-release-action@1.1.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.ref }}
           overwrite: true
           asset_name: clowder.epub
           file: doc/src/sphinx/_build/epub/Clowder.epub
+      - name: Upload epub to NCSA
+        if: github.event_name == 'push'
+        uses: robkooper/sftp-action@master
+        with:
+          host: ${{ secrets.SCP_HOST }}
+          username: ${{ secrets.SCP_USERNAME }}
+          key: ${{ secrets.SCP_KEY }}
+          files: "doc/src/sphinx/_build/epub/Clowder.epub"
+          target: "CATS/${{ env.CLOWDER_VERSION }}/files"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,10 @@
 name: Docker
 
+# initially we would us on: [release] as well, the problem is that
+# the code in clowder would not know what branch the code is in,
+# and would not set the right version flags.
+
 # This will run when:
-# - a new release is created, to make sure the right tags of the
-#   docker images are pushed (expects tags to be v1.8.4).
 # - when new code is pushed to master/develop to push the tags
 #   latest and develop
 # - when a pull request is created and updated  to make sure the
@@ -12,9 +14,6 @@ name: Docker
 # - DOCKERHUB_USERNAME : username that can push to the org
 # - DOCKERHUB_PASSWORD : password asscoaited with the username
 on:
-  release:
-    types: created
-
   push:
     branches:
       - master
@@ -63,24 +62,48 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # calculate some variables that are used later
+      - name: github branch
+        run: |
+          BRANCH=${GITHUB_REF##*/}
+          echo "::set-env name=GITHUB_BRANCH::${BRANCH}"
+          if [ "$BRANCH" == "master" ]; then
+            version="$(awk '/version = / { print $4 }' project/Build.scala | sed 's/"//g')"
+            tags="latest"
+            oldversion=""
+            while [ "${oldversion}" != "${version}" ]; do
+              oldversion="${version}"
+              tags="${tags},${version}"
+              version=${version%.*}
+            done
+            echo "::set-env name=CLOWDER_VERSION::$(awk '/version = / { print $4 }' project/Build.scala | sed 's/"//g')"
+            echo "::set-env name=CLOWDER_TAGS::${tags}"
+          elif [ "$BRANCH" == "develop" ]; then
+            echo "::set-env name=CLOWDER_VERSION::develop"
+            echo "::set-env name=CLOWDER_TAGS::develop"
+          else 
+            echo "::set-env name=CLOWDER_VERSION::testing"
+            echo "::set-env name=CLOWDER_TAGS::"
+          fi
+
       # build the docker image, this will always run to make sure
       # the Dockerfile still works.
       - name: Build image
         run: |
           docker build \
-            --build-arg BRANCH=${{ github.ref }} \
-            --build-arg VERSION=${{ github.run_number }} \
+            --build-arg BRANCH=${GITHUB_BRANCH} \
+            --build-arg VERSION=${CLOWDER_VERSION} \
             --build-arg BUILDNUMBER=${{ github.run_number }} \
             --build-arg GITSHA1=${{ github.sha  }} \
             --tag image ${{ matrix.FOLDER }}
 
       # this will publish to the actor (person) github packages
       - name: Publish to GitHub
-        if: github.event_name != 'pull_request'
-        uses: elgohr/Publish-Docker-Github-Action@2.14
+        if: github.event_name == 'push'
+        uses: elgohr/Publish-Docker-Github-Action@2.18
         env:
-          BRANCH: ${{ github.ref }}
-          VERSION: ${{ github.run_number }}
+          BRANCH: ${{ env.GITHUB_BRANCH }}
+          VERSION: ${{ env.CLOWDER_VERSION }}
           BUILDNUMBER: ${{ github.run_number }}
           GITSHA1: ${{ github.sha  }}
         with:
@@ -88,18 +111,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
           context: ${{ matrix.FOLDER }}
-          tag_semver: true
-          tag_names: true
+          tags: "${{ env.CLOWDER_TAGS }}"
           registry: docker.pkg.github.com
           buildargs: BRANCH,VERSION,BUILDNUMBER,GITSHA1
 
       # this will publish to the clowder dockerhub repo
       - name: Publish to Docker Hub
-        if: github.event_name != 'pull_request' && github.repository == env.MASTER_REPO
-        uses: elgohr/Publish-Docker-Github-Action@2.14
+        if: github.event_name == 'push' && github.repository == env.MASTER_REPO
+        uses: elgohr/Publish-Docker-Github-Action@2.18
         env:
-          BRANCH: ${{ github.ref }}
-          VERSION: ${{ github.run_number }}
+          BRANCH: ${{ env.GITHUB_BRANCH }}
+          VERSION: ${{ env.CLOWDER_VERSION }}
           BUILDNUMBER: ${{ github.run_number }}
           GITSHA1: ${{ github.sha  }}
         with:
@@ -107,25 +129,31 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
           context: ${{ matrix.FOLDER }}
-          tag_semver: true
-          tag_names: true
+          tags: "${{ env.CLOWDER_TAGS }}"
           buildargs: BRANCH,VERSION,BUILDNUMBER,GITSHA1
 
       # this will update the README of the dockerhub repo
       - name: check file
         id: filecheck
-        if: github.event_name == 'release' && github.repository == env.MASTER_REPO
         run: |
-          if [ "${{ matrix.README }}" != "" -a -e "${{ matrix.README }}" ]; then
-            echo "##[set-output name=exists;]true"
+          if [ "${{ matrix.README }}" != "" ]; then
+            if [ -e "${{ matrix.README }}" ]; then
+              echo "##[set-output name=readme;]${{ matrix.README }}"
+            else
+              echo "##[set-output name=readme;]"
+            fi
           else
-            echo "##[set-output name=exists;]false"
+            if [ -e "${{ matrix.FOLDER }}/README.md" ]; then
+              echo "##[set-output name=readme;]${{ matrix.FOLDER }}/README.md"
+            else
+              echo "##[set-output name=readme;]"
+            fi
           fi
       - name: Docker Hub Description
-        if: github.event_name == 'release' && github.repository == env.MASTER_REPO && steps.filecheck.outputs.exists == 'true'
+        if: github.event_name == 'push' && github.repository == env.MASTER_REPO && env.BRANCH == 'master' && steps.filecheck.outputs.readme != ''
         uses: peter-evans/dockerhub-description@v2
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
           DOCKERHUB_REPOSITORY: ${{ env.DOCKERHUB_ORG }}/${{ matrix.IMAGE }}
-          README_FILEPATH: ${{ matrix.README }}
+          README_FILEPATH: ${{ steps.filecheck.outputs.readme }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+- Queue threads (e.g. indexer) will no longer crash permanently if the queue connection is lost temporarily.
+
 ## 1.10.0 - 2020-06-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+## 1.10.1 - Unreleased
 
 ### Fixed
 - Queue threads (e.g. indexer) will no longer crash permanently if the queue connection is lost temporarily.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Queue threads (e.g. indexer) will no longer crash permanently if the queue connection is lost temporarily.
+- Docker images would not build correctly.
+- If monitor HTTP server would crash, it would not restart correctly.
+
+### Added
+- Artifacts can be uploaded using SCP to remote server.
 
 ## 1.10.0 - 2020-06-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Queue threads (e.g. indexer) will no longer crash permanently if the queue connection is lost temporarily.
 - Docker images would not build correctly.
 - If monitor HTTP server would crash, it would not restart correctly.
+- Don't call server side twice when rendering list of files on dataset page.
+  [#7](https://github.com/clowder-framework/clowder/issues/7)
 
 ### Added
 - Artifacts can be uploaded using SCP to remote server.

--- a/app/services/RabbitmqPlugin.scala
+++ b/app/services/RabbitmqPlugin.scala
@@ -1215,7 +1215,7 @@ class ExtractorsHeartbeats(channel: Channel, queue: String) extends Actor {
       // Update database
       extractionInfoResult.fold(
         errors => {
-          Logger.error("Received extractor heartbeat with bad format: " + extractor_info)
+          Logger.debug("Received extractor heartbeat with bad format: " + extractor_info)
         },
         info => {
           extractorsService.getExtractorInfo(info.name) match {

--- a/app/services/mongodb/MongoDBQueueService.scala
+++ b/app/services/mongodb/MongoDBQueueService.scala
@@ -71,13 +71,14 @@ trait MongoDBQueueService {
   def getNextQueuedAction(): Option[QueuedAction] = {
     try {
       val response = Queue.findOne(new MongoDBObject)
-      return Queue.findOne(new MongoDBObject)
+      respone
     } catch {
       case e: MongoException => {
         // TODO: Will generate an error message every 5ms while Mongo is inaccessible...
         //Logger.error("Problem connecting to MongoDB queue.")
-        return None
+        None
       }
+      case _ => None
     }
 
   }

--- a/app/services/mongodb/MongoDBQueueService.scala
+++ b/app/services/mongodb/MongoDBQueueService.scala
@@ -75,7 +75,9 @@ trait MongoDBQueueService {
     } catch {
       case e: MongoException => {
         // TODO: Will generate an error message every 5ms while Mongo is inaccessible...
-        //Logger.error("Problem connecting to MongoDB queue.")
+        // TODO: Make this happen only once, with a flag, then Logger.info when it comes back
+        // TODO: Have a critical vs. noncritical Mongo call that auto wraps this? Lots of calls dont catch
+        Logger.error("Problem connecting to MongoDB queue.")
         None
       }
       case _ => None

--- a/app/services/mongodb/MongoDBQueueService.scala
+++ b/app/services/mongodb/MongoDBQueueService.scala
@@ -71,7 +71,7 @@ trait MongoDBQueueService {
   def getNextQueuedAction(): Option[QueuedAction] = {
     try {
       val response = Queue.findOne(new MongoDBObject)
-      respone
+      response
     } catch {
       case e: MongoException => {
         // TODO: Will generate an error message every 5ms while Mongo is inaccessible...

--- a/app/services/mongodb/MongoDBQueueService.scala
+++ b/app/services/mongodb/MongoDBQueueService.scala
@@ -5,6 +5,7 @@ import java.util.Date
 import akka.actor.Cancellable
 import api.Permission.Permission
 import com.mongodb.casbah.Imports._
+import com.mongodb.MongoException
 import com.novus.salat.dao.{SalatDAO, ModelCompanion}
 import models.{File, _}
 import org.bson.types.ObjectId
@@ -68,7 +69,17 @@ trait MongoDBQueueService {
 
   // get next entry from queue
   def getNextQueuedAction(): Option[QueuedAction] = {
-    return Queue.findOne(new MongoDBObject)
+    try {
+      val response = Queue.findOne(new MongoDBObject)
+      return Queue.findOne(new MongoDBObject)
+    } catch {
+      case e: MongoException => {
+        // TODO: Will generate an error message every 5ms while Mongo is inaccessible...
+        //Logger.error("Problem connecting to MongoDB queue.")
+        return None
+      }
+    }
+
   }
 
   // start pool to being processing queue actions

--- a/app/views/dataset.scala.html
+++ b/app/views/dataset.scala.html
@@ -524,95 +524,93 @@
 		    });
 
         }
-    var cur_description;
-    function updateDescription() {
-		cur_description = $('#ds_description').html().trim();
-		$('<div class="edit_desc"> </div>').insertAfter($('#ds_description'));
-		$('.edit_desc').append('<textarea id = "desc_input" class="form-control"/>');
-		$('.edit_desc').append('<button id = "update_desc" class= "btn btn-sm btn-primary btn-margins" onclick = "saveDescription()"> <span class="glyphicon glyphicon-send"> </span> Save </button>');
-		$('.edit_desc').append('<button id="cancel_desc" class="btn btn-sm edit-tab btn-default btn-margins" onclick="cancelDescription()"> <span class="glyphicon glyphicon-remove"></span> Cancel </button>');
-		if(cur_description.indexOf("Add a description") != 0) {
-		    $('#desc_input').val(htmlDecode(cur_description.replace(new RegExp("<br>", "g"), "\n")));
-		}
-		$('#ds_description').text("");
-		$('#edit-description').css("display", "none");
-		$('#edit-description').addClass("hiddencomplete");
-		$('#ds_description').css("display", "none");
-		$("#desc_input").select();
-	}
-
-    function cancelDescription() {
-        $('#ds_description').html(cur_description);
-        $('.edit_desc').remove();
-        $('#ds_description').css("display","");
-        $('#edit-description').removeClass("inline");
-        $('#edit-description').css("display", "");
-        $('#ds-description').mouseleave();
-    }
-
-	function saveDescription() {
-		var description = $('#desc_input').val();
-		var encDescription = htmlEncode(description);
-		jsonData = JSON.stringify({"description": encDescription});
-
-		var request = jsRoutes.api.Datasets.updateDescription("@dataset.id").ajax({
-			data: jsonData,
-			type: 'PUT',
-			contentType: "application/json"
-		});
-
-		request.done(function(response, textStatus,jqXHR) {
-			$('#ds_description').html(urlify(htmlEncode(description).replace(/\n/g, "<br>")));
-						if($('#ds_description').html().length == 0) {
-			   $('#aboutdesc > span').text("Add a " + descLabel.toLowerCase());
-			 } else {
-			   $('#aboutdesc > span').text(descLabel + ":");
-			 }
-			$('.edit_desc').remove();
-			//multiline add classes else remove them
-			if ($('#ds_description').html().indexOf("<br>")>=0) {
-			$('#ds_description').addClass("abstract-panel");
-			} else {
-			$('#ds_description').removeClass("abstract-panel");
-			}
-			$('#ds_description').css("display", "");
-			$('#edit-description').removeClass("inline");
-            $('#edit-description').css("display", "");
-            $('#ds-description').mouseleave();
-            notify("Dataset description updated successfully", "success", false, 2000 );
-		});
-
-		request.fail(function(jqXHR, textStatus, errorThrown) {
-			console.error("The following error occurred: " + textStatus, errorThrown);
-			var errMsg = " You must be logged in to update the information about a dataset.";
-			if(!checkErrorAndRedirect(jqXHR, errMsg)) {
-				notify("The dataset information was not updated due to: " + errorThrown, "error");
-			}
-		});
-
-	 }
-
-    function urlify(text) {
-        var urlRegex =/(\b(https?|ftp|file):\/\/[-A-Z0-9+&@@#\/%?=~_|!:,.;]*[-A-Z0-9+&@@#\/%=~_|])/ig;
-        return text.replace(urlRegex, function(url) {
-            return '<a href="' + url + '">' + url + '</a>';
-        })
-    }
-
-    function refreshToolSidebar() {
-        // Get current status from ToolManagerPlugin and refresh sidebar table
-        var request = new XMLHttpRequest();
-        request.onreadystatechange = function() {
-            if (request.readyState == 4 && request.status == 200) {
-                $('#toolListContainer').html(request.response);
+        var cur_description;
+        function updateDescription() {
+            cur_description = $('#ds_description').html().trim();
+            $('<div class="edit_desc"> </div>').insertAfter($('#ds_description'));
+            $('.edit_desc').append('<textarea id = "desc_input" class="form-control"/>');
+            $('.edit_desc').append('<button id = "update_desc" class= "btn btn-sm btn-primary btn-margins" onclick = "saveDescription()"> <span class="glyphicon glyphicon-send"> </span> Save </button>');
+            $('.edit_desc').append('<button id="cancel_desc" class="btn btn-sm edit-tab btn-default btn-margins" onclick="cancelDescription()"> <span class="glyphicon glyphicon-remove"></span> Cancel </button>');
+            if(cur_description.indexOf("Add a description") != 0) {
+                $('#desc_input').val(htmlDecode(cur_description.replace(new RegExp("<br>", "g"), "\n")));
             }
+            $('#ds_description').text("");
+            $('#edit-description').css("display", "none");
+            $('#edit-description').addClass("hiddencomplete");
+            $('#ds_description').css("display", "none");
+            $("#desc_input").select();
         }
 
-        request.open("GET", jsRoutes.controllers.ToolManager.refreshToolSidebar("@dataset.id", "@dataset.name").url, true);
-        request.send();
-    }
+        function cancelDescription() {
+            $('#ds_description').html(cur_description);
+            $('.edit_desc').remove();
+            $('#ds_description').css("display","");
+            $('#edit-description').removeClass("inline");
+            $('#edit-description').css("display", "");
+            $('#ds-description').mouseleave();
+        }
 
-    $(function() {
+        function saveDescription() {
+                var description = $('#desc_input').val();
+                var encDescription = htmlEncode(description);
+                jsonData = JSON.stringify({"description": encDescription});
+
+                var request = jsRoutes.api.Datasets.updateDescription("@dataset.id").ajax({
+                    data: jsonData,
+                    type: 'PUT',
+                    contentType: "application/json"
+                });
+
+                request.done(function(response, textStatus,jqXHR) {
+                    $('#ds_description').html(urlify(htmlEncode(description).replace(/\n/g, "<br>")));
+                    if($('#ds_description').html().length == 0) {
+                        $('#aboutdesc > span').text("Add a " + descLabel.toLowerCase());
+                    } else {
+                        $('#aboutdesc > span').text(descLabel + ":");
+                    }
+                    $('.edit_desc').remove();
+                    //multiline add classes else remove them
+                    if ($('#ds_description').html().indexOf("<br>")>=0) {
+                        $('#ds_description').addClass("abstract-panel");
+                    } else {
+                        $('#ds_description').removeClass("abstract-panel");
+                    }
+                    $('#ds_description').css("display", "");
+                    $('#edit-description').removeClass("inline");
+                    $('#edit-description').css("display", "");
+                    $('#ds-description').mouseleave();
+                    notify("Dataset description updated successfully", "success", false, 2000 );
+                });
+
+                request.fail(function(jqXHR, textStatus, errorThrown) {
+                    console.error("The following error occurred: " + textStatus, errorThrown);
+                    var errMsg = " You must be logged in to update the information about a dataset.";
+                    if(!checkErrorAndRedirect(jqXHR, errMsg)) {
+                        notify("The dataset information was not updated due to: " + errorThrown, "error");
+                    }
+                });
+            }
+
+        function urlify(text) {
+            var urlRegex =/(\b(https?|ftp|file):\/\/[-A-Z0-9+&@@#\/%?=~_|!:,.;]*[-A-Z0-9+&@@#\/%=~_|])/ig;
+            return text.replace(urlRegex, function(url) {
+                return '<a href="' + url + '">' + url + '</a>';
+            })
+        }
+
+        function refreshToolSidebar() {
+            // Get current status from ToolManagerPlugin and refresh sidebar table
+            var request = new XMLHttpRequest();
+            request.onreadystatechange = function() {
+                if (request.readyState == 4 && request.status == 200) {
+                    $('#toolListContainer').html(request.response);
+                }
+            }
+            request.open("GET", jsRoutes.controllers.ToolManager.refreshToolSidebar("@dataset.id", "@dataset.name").url, true);
+            request.send();
+        }
+
+        $(function() {
             $(window).on('fileDelete hashchange', function() {
                 getUpdatedFilesAndFolders();
             });
@@ -659,23 +657,21 @@
         });
 
         @if(play.Play.application().configuration().getBoolean("sortInMemory")) {
-        function updatePageAndFolder(idx, folderIdd, sort) {
-            if (folderIdd != "") {
-                location.hash = "folderId=" + folderIdd + "&page=" + idx + "&sort=" + sort;
-            } else {
-                location.hash = "page=" + idx + "&sort=" + sort;
+            function updatePageAndFolder(idx, folderIdd, sort) {
+                if (folderIdd != "") {
+                    location.hash = "folderId=" + folderIdd + "&page=" + idx + "&sort=" + sort;
+                } else {
+                    location.hash = "page=" + idx + "&sort=" + sort;
+                }
             }
-            $(window).trigger("hashchange");
-        }
         } else {
-       function updatePageAndFolder(idx, folderIdd){
-           if(folderIdd != "") {
-               location.hash = "folderId="+folderIdd+"&page="+idx;
-           } else {
-               location.hash="page="+idx;
-           }
-           $(window).trigger("hashchange");
-       }
+            function updatePageAndFolder(idx, folderIdd){
+                if(folderIdd != "") {
+                    location.hash = "folderId="+folderIdd+"&page="+idx;
+                } else {
+                    location.hash="page="+idx;
+                }
+            }
         }
 
        function getUpdatedFilesAndFolders() {

--- a/doc/src/sphinx/conf.py
+++ b/doc/src/sphinx/conf.py
@@ -20,7 +20,7 @@ copyright = '2019, University of Illinois at Urbana-Champaign'
 author = 'Luigi Marini'
 
 # The full version, including alpha/beta/rc tags
-release = '1.10.0'
+release = '1.10.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -17,10 +17,9 @@ object ApplicationBuild extends Build {
   val jvm = "1.7"
 
   def appVersion: String = {
-    if (gitBranchName == "master") {
-      getVersion
-    } else {
-      s"${getVersion}-SNAPSHOT"
+    gitBranchName match {
+      case "master" => getVersion
+      case _ => s"${getVersion}-develop"
     }
   }
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -13,7 +13,7 @@ import NativePackagerKeys._
 object ApplicationBuild extends Build {
 
   val appName = "clowder"
-  val version = "1.10.0"
+  val version = "1.10.1"
   val jvm = "1.7"
 
   def appVersion: String = {

--- a/public/swagger.yml
+++ b/public/swagger.yml
@@ -9,7 +9,7 @@ info:
     Clowder is a customizable and scalable data management system to support any
     data format and multiple research domains. It is under active development
     and deployed for a variety of research projects.
-  version: 1.10.0
+  version: 1.10.1
   termsOfService: https://clowder.ncsa.illinois.edu/clowder/tos
   contact:
     name: Clowder

--- a/scripts/monitor/monitor.py
+++ b/scripts/monitor/monitor.py
@@ -58,6 +58,9 @@ def http_server(host_port=9999):
     server = http.server.HTTPServer(("", host_port), MyServer)
     try:
         server.serve_forever()
+    except:
+        logging.exception("Error in http server")
+        sys.exit(1)
     finally:
         server.server_close()
 


### PR DESCRIPTION
BUG: If Clowder instance was using ElasticsearchQueue enabled, a thread will check every 5ms for actions queued in MongoDB collection to perform. If MongoDB goes down (even briefly e.g. switchover of PRIMARY) and that thread tries to fetch an action, the thread would crash and the queue would never get processed, only grow.

This adds a try/catch around the fetching of next queued action, and if an error is encountered it simply returns none ("no actions to take.") It will continue to return none until Mongo is accessible again, at which point it resumes processing.