### PR TITLE
use long for content length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - typesafe now only offers https access
   [#49](https://github.com/clowder-framework/clowder/issues/49)
+- if uploading files by url > 2147483647 it would fail
+  [#54](https://github.com/clowder-framework/clowder/issues/54)
 
 ## 1.10.1 - 2020-07-16
 

--- a/app/util/FileUtils.scala
+++ b/app/util/FileUtils.scala
@@ -657,7 +657,7 @@ object FileUtils {
     // actually save the file
     val conn = url.openConnection()
 
-    ByteStorageService.save(conn.getInputStream, "uploads", conn.getContentLength) match {
+    ByteStorageService.save(conn.getInputStream, "uploads", conn.getContentLengthLong) match {
       case Some((loader_id, loader, length)) => {
         files.get(file.id) match {
           case Some(f) => {


### PR DESCRIPTION
## Description
This will use the long method to get the content length. This will work such that we can upload files larger than 2147483647 by url.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [X] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [X] I have updated the CHANGELOG.md.
- [ ] I have signed the CLA
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
