### PR TITLE
Fix proxy and more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+- proxy will no correctly handle paths that end with a / at the end.
+
 ## 1.11.0 - 2020-08-31
 
 ### Added

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -31,8 +31,8 @@ class Application @Inject() (files: FileService, collections: CollectionService,
    * @param path the path minus the slash
    * @return moved permanently to path without /
    */
-  def untrail(path: String) = Action {
-    MovedPermanently("/" + path)
+  def untrail(path: String) = Action { implicit request =>
+    MovedPermanently(s"${Utils.baseUrl(request, false)}/${path}")
   }
 
   def swaggerUI = Action { implicit request =>

--- a/app/controllers/Utils.scala
+++ b/app/controllers/Utils.scala
@@ -14,8 +14,12 @@ object Utils {
    * Return base url given a request. This will add http or https to the front, for example
    * https://localhost:9443 will be returned if it is using https.
    */
-  def baseUrl(request: Request[Any]) = {
-    routes.Files.list().absoluteURL(https(request))(request).replace("/files", "")
+  def baseUrl(request: Request[Any], absolute: Boolean = true) = {
+    if (absolute) {
+      routes.Files.list().absoluteURL(https(request))(request).replace("/files", "")
+    } else {
+      routes.Files.list().url.replace("/files", "")
+    }
   }
 
   /**

--- a/conf/routes
+++ b/conf/routes
@@ -7,6 +7,13 @@
 
 #OPTIONS       /*path                                                                   @controllers.Application.options(path)
 OPTIONS        /*path                                                                   api.ApiHelp.options(path)
+
+# operations are applied in this order, to prevent untrail from removing
+# the trailing / at the end of the /api/proxy calls it is placed before
+# the untrail call
+GET            /api/proxy/:endpoint_key                                                 @api.Proxy.get(endpoint_key: String, pathSuffix: String = null)
+GET            /api/proxy/:endpoint_key/                                                @api.Proxy.get(endpoint_key: String, pathSuffix: String = "")
+GET            /api/proxy/:endpoint_key/*pathSuffix                                     @api.Proxy.get(endpoint_key: String, pathSuffix: String)
 GET            /*path/                                                                  @controllers.Application.untrail(path: String)
 
 # ----------------------------------------------------------------------
@@ -859,17 +866,14 @@ DELETE       /api/standardvocab/:id                                             
 # PROXY API
 # ----------------------------------------------------------------------
 
-GET         /api/proxy/:endpoint_key                                                        @api.Proxy.get(endpoint_key: String, pathSuffix: String = null)
-GET         /api/proxy/:endpoint_key/                                                       @api.Proxy.get(endpoint_key: String, pathSuffix: String = null)
-GET         /api/proxy/:endpoint_key/*pathSuffix                                            @api.Proxy.get(endpoint_key: String, pathSuffix: String)
 POST        /api/proxy/:endpoint_key                                                        @api.Proxy.post(endpoint_key: String, pathSuffix: String = null)
-POST        /api/proxy/:endpoint_key/                                                       @api.Proxy.post(endpoint_key: String, pathSuffix: String = null)
+POST        /api/proxy/:endpoint_key/                                                       @api.Proxy.post(endpoint_key: String, pathSuffix: String = "")
 POST        /api/proxy/:endpoint_key/*pathSuffix                                            @api.Proxy.post(endpoint_key: String, pathSuffix: String)
 PUT         /api/proxy/:endpoint_key                                                        @api.Proxy.put(endpoint_key: String, pathSuffix: String = null)
-PUT         /api/proxy/:endpoint_key/                                                       @api.Proxy.put(endpoint_key: String, pathSuffix: String = null)
+PUT         /api/proxy/:endpoint_key/                                                       @api.Proxy.put(endpoint_key: String, pathSuffix: String = "")
 PUT         /api/proxy/:endpoint_key/*pathSuffix                                            @api.Proxy.put(endpoint_key: String, pathSuffix: String)
 DELETE      /api/proxy/:endpoint_key                                                        @api.Proxy.delete(endpoint_key: String, pathSuffix: String = null)
-DELETE      /api/proxy/:endpoint_key/                                                       @api.Proxy.delete(endpoint_key: String, pathSuffix: String = null)
+DELETE      /api/proxy/:endpoint_key/                                                       @api.Proxy.delete(endpoint_key: String, pathSuffix: String = "")
 DELETE      /api/proxy/:endpoint_key/*pathSuffix                                            @api.Proxy.delete(endpoint_key: String, pathSuffix: String)
 
 # ----------------------------------------------------------------------

--- a/public/jsonld/contexts/extractors.jsonld
+++ b/public/jsonld/contexts/extractors.jsonld
@@ -3,7 +3,7 @@
 	"extractor": "https://clowder.ncsa.illinois.edu/contexts/extractor#",
 	"id":"extractor/internal_id",
 	"name": {"@id": "extractor:extractor/id", "@type": "@id"},
-	"version": "extractor:version"
+	"version": "extractor:version",
 	"created_at": {
 	      "@id": "extractor:updated",
 	      "@type": "http://www.w3.org/2001/XMLSchema#dateTime"

--- a/public/jsonld/contexts/metadata.jsonld
+++ b/public/jsonld/contexts/metadata.jsonld
@@ -20,11 +20,9 @@
     "extractor": "cat:extractor",
     "content": {
       "@id": "https://clowder.ncsa.illinois.edu/metadata#content"
-    }
+    },
     "attached_to": "https://clowder.ncsa.illinois.edu/metadata/attachedTo",
     "resource_type": "https://clowder.ncsa.illinois.edu/resource/type",
     "url": "https://clowder.ncsa.illinois.edu/resource"
   }
 }
-
-


### PR DESCRIPTION
## Description

This fixes 3 things:
- if a proxy call ends with a / it will be stripped, it now leaves the / at the end
- if a path ends with a / it will now get rewritten with the correct prefix
- fix 2 missing , in the jsonld files

I tried to fix the code for untrail to catch the /api/proxy calls, but it became messy. Since the conf/routes is executed in order, moving these calls to the top of the file fixed the problem.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [X] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [X] I have updated the CHANGELOG.md.
- [ ] I have signed the CLA
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
