### PR TITLE
Fix Traefik issue with path prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - added healtz endpoint that is cheap and quick to return, useful for kubernetes live/ready checks.
 
 ### Fixed
+- Fixed health check script when using custom path prefix
 - proxy will no correctly handle paths that end with a / at the end.
 
 ### CHanged

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,5 +1,6 @@
 Following is a list of contributors in alphabetical order:
 
+- Aaraj Habib
 - Ashwini Vaidya
 - Avinash Kumar
 - Ben Galewsky

--- a/docker/healthcheck.sh
+++ b/docker/healthcheck.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
-curl -s --fail http://localhost:9000/api/status || exit 1
+### Add trailing backslash if not in context
+[[ "${CLOWDER_CONTEXT}" != */ ]] && CLOWDER_CONTEXT="${CLOWDER_CONTEXT}/"
+
+curl -s --fail http://localhost:8000${CLOWDER_CONTEXT:-/}api/status || exit 1


### PR DESCRIPTION
## Description
Setting a value for CLOWDER_CONTEXT caused docker health-check to fail leading to traefik ignoring the container. This PR adds the clowder_context to the health check script if provided, which fixes the health-check and traefik issues with the container.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [x] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have signed the CLA
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
