### PR TITLE
fix problem with healthcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.11.2 - 2020-10-12
+
+### Fixed
+- clowder healthcheck was not correct, resulting in docker-compose never thinking it was healthy. This could also result in traefik not setting up the routes. 
+
 ## 1.11.1 - 2020-09-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 1.11.2 - 2020-10-12
+## 1.11.2 - 2020-10-13
 
 ### Fixed
-- clowder healthcheck was not correct, resulting in docker-compose never thinking it was healthy. This could also result in traefik not setting up the routes. 
+- Clowder healthcheck was not correct, resulting in docker-compose never thinking it was healthy. This could also result in traefik not setting up the routes. 
 
 ## 1.11.1 - 2020-09-29
 

--- a/doc/src/sphinx/conf.py
+++ b/doc/src/sphinx/conf.py
@@ -22,7 +22,7 @@ copyright = '2019, University of Illinois at Urbana-Champaign'
 author = 'Luigi Marini'
 
 # The full version, including alpha/beta/rc tags
-release = '1.11.1'
+release = '1.11.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docker/healthcheck.sh
+++ b/docker/healthcheck.sh
@@ -3,4 +3,4 @@
 ### Add trailing backslash if not in context
 [[ "${CLOWDER_CONTEXT}" != */ ]] && CLOWDER_CONTEXT="${CLOWDER_CONTEXT}/"
 
-curl -s --fail http://localhost:8000${CLOWDER_CONTEXT:-/}api/status || exit 1
+curl -s --fail http://localhost:9000${CLOWDER_CONTEXT:-/}healthz || exit 1

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -13,7 +13,7 @@ import NativePackagerKeys._
 object ApplicationBuild extends Build {
 
   val appName = "clowder"
-  val version = "1.11.1"
+  val version = "1.11.2"
   val jvm = "1.7"
 
   def appVersion: String = {

--- a/public/swagger.yml
+++ b/public/swagger.yml
@@ -9,7 +9,7 @@ info:
     Clowder is a customizable and scalable data management system to support any
     data format and multiple research domains. It is under active development
     and deployed for a variety of research projects.
-  version: 1.11.1
+  version: 1.11.2
   termsOfService: https://clowder.ncsa.illinois.edu/clowder/tos
   contact:
     name: Clowder


### PR DESCRIPTION
## Description

When running clowder in docker-compose.yml the healthcheck would never get marked as healthy. This was due to trying to connect to port 8000, not port 9000. Also switched to use the /healthz endpoint that will return `healthy` fast.

@cconsta1 thanks for checking and bringing up the issue.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [X] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [X] I have updated the CHANGELOG.md.
- [ ] I have signed the CLA
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
