### PR TITLE
Make space ID optional on storage reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Added a new `/api/reports/metrics/extractors` report for summarizing extractor usage by user.
 
+### Changed
+- api/reports/storage/spaces endpoint now accepts a space parameter for ID rather than requiring a space filter.
+
 ## 1.13.0 - 2020-12-02
 
 ### Added
@@ -16,9 +19,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Support for Amplitude clickstream tracking. See Admin -> Customize to configure Amplitude apikey.
 - UpdateUserId.js to scripts/updates. This code adds user_id to each document in extractions collection in mongodb. 
   user_id is taken from author id in uploads.files if exists, else it taken from author id in datasets collection.
-
-### Changed
-- api/reports/storage/spaces endpoint now accepts a space parameter for ID rather than requiring a space filter.
 
 ### Fixed
 - An extractor with file matching set to `*/*` (all file types) would incorrectly send out dataset events.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   user_id is taken from author id in uploads.files if exists, else it taken from author id in datasets collection.
 - Ability to submit multiple selected files within a dataset to an extractor.
 
+### Changed
+- api/reports/storage/spaces endpoint now accepts a space parameter for ID rather than requiring a space filter.
+
 ### Fixed
 - GeospatialViewer preview tab should no longer show if it does not contain any rendered data.
 - Editor can now delete tags on files, datasets and sections.

--- a/app/api/Reporting.scala
+++ b/app/api/Reporting.scala
@@ -394,9 +394,9 @@ class Reporting @Inject()(selections: SelectionService,
     return contents
   }
 
-  def spaceStorage(id: UUID, since: Option[String], until: Option[String]) = ServerAdminAction { implicit request =>
+  def spaceStorage(space: Option[String], since: Option[String], until: Option[String]) = ServerAdminAction { implicit request =>
     // Iterate over the files of every dataset in the space
-    val results = datasets.getIterator(Some(id), None, None) // TODO: Can't use time filters here if user intends files
+    val results = datasets.getIterator(space, None, None) // TODO: Can't use time filters here if user intends files
 
     var headerRow = true
     val enum = Enumerator.generateM({
@@ -495,9 +495,13 @@ class Reporting @Inject()(selections: SelectionService,
       Future(chunk)
     })
 
+    val filename = space match {
+      case Some(spid) => "SpaceStorage_"+spid+".csv"
+      case None => "SpaceStorage.csv"
+    }
     Ok.chunked(enum.andThen(Enumerator.eof)).withHeaders(
       "Content-Type" -> "text/csv",
-      "Content-Disposition" -> ("attachment; filename=SpaceStorage"+id.stringify+".csv")
+      "Content-Disposition" -> ("attachment; filename="+filename)
     )
   }
 }

--- a/app/services/DatasetService.scala
+++ b/app/services/DatasetService.scala
@@ -383,6 +383,6 @@ trait DatasetService {
 
   def incrementDownloads(id: UUID, user: Option[User])
 
-  def getIterator(space: Option[UUID], since: Option[String], until: Option[String]): Iterator[Dataset]
+  def getIterator(space: Option[String], since: Option[String], until: Option[String]): Iterator[Dataset]
 
 }

--- a/app/services/FileService.scala
+++ b/app/services/FileService.scala
@@ -246,6 +246,6 @@ trait FileService {
 
   def incrementDownloads(id: UUID, user: Option[User])
 
-  def getIterator(space: Option[UUID], since: Option[String], until: Option[String]): Iterator[File]
+  def getIterator(space: Option[String], since: Option[String], until: Option[String]): Iterator[File]
 
 }

--- a/app/services/mongodb/MongoDBDatasetService.scala
+++ b/app/services/mongodb/MongoDBDatasetService.scala
@@ -1641,9 +1641,9 @@ class MongoDBDatasetService @Inject() (
    * @param since - include only datasets created after a certain date
    * @param until - include only datasets created before a certain date
    */
-  def getIterator(space: Option[UUID], since: Option[String], until: Option[String]): Iterator[Dataset] = {
+  def getIterator(space: Option[String], since: Option[String], until: Option[String]): Iterator[Dataset] = {
     var query = MongoDBObject("trash" -> false)
-    space.foreach(spid => query += ("spaces" -> new ObjectId(spid.stringify)))
+    space.foreach(spid => query += ("spaces" -> new ObjectId(spid)))
     since.foreach(t => query = query ++ ("created" $gte Parsers.fromISO8601(t)))
     until.foreach(t => query = query ++ ("created" $lte Parsers.fromISO8601(t)))
     Dataset.find(query)

--- a/app/services/mongodb/MongoDBFileService.scala
+++ b/app/services/mongodb/MongoDBFileService.scala
@@ -1215,7 +1215,7 @@ class MongoDBFileService @Inject() (
     }
   }
 
-  def getIterator(space: Option[UUID], since: Option[String], until: Option[String]): Iterator[File] = {
+  def getIterator(space: Option[String], since: Option[String], until: Option[String]): Iterator[File] = {
     var query = MongoDBObject()
     space.foreach(spid => {
       // If space is specified, we have to get that association from datasets for now

--- a/conf/routes
+++ b/conf/routes
@@ -756,7 +756,7 @@ GET            /api/reports/metrics/datasets                                    
 GET            /api/reports/metrics/collections                                         @api.Reporting.collectionMetrics()
 GET            /api/reports/metrics/spaces                                              @api.Reporting.spaceMetrics()
 GET            /api/reports/metrics/users                                               @api.Reporting.userMetrics()
-GET            /api/reports/storage/spaces/:id                                          @api.Reporting.spaceStorage(id: UUID, since: Option[String] ?= None, until: Option[String] ?= None)
+GET            /api/reports/storage/spaces                                              @api.Reporting.spaceStorage(space: Option[String] ?= None, since: Option[String] ?= None, until: Option[String] ?= None)
 
 # ----------------------------------------------------------------------
 # MISC./OTHER ENDPOINTS

--- a/public/swagger.yml
+++ b/public/swagger.yml
@@ -5005,17 +5005,17 @@ paths:
         Must be a server admin to access the report. Supports ISO8601 date range filters.
       parameters:
         - name: space
-          in: path
+          in: query
           required: false
           schema:
             type: string
         - name: since
-          in: path
+          in: query
           required: false
           schema:
             type: string
         - name: until
-          in: path
+          in: query
           required: false
           schema:
             type: string

--- a/public/swagger.yml
+++ b/public/swagger.yml
@@ -4995,18 +4995,18 @@ paths:
           description: Not authorized
           content: {}
 
-  /reports/storage/spaces/{id}:
+  /reports/storage/spaces:
     get:
       tags:
         - reporting
       summary: Download storage metrics report for spaces as CSV.
       description: |
-        Download storage metrics report for files in a space as a CSV file.
+        Download storage metrics report for files in a space as a CSV file. Space id is optional parameter.
         Must be a server admin to access the report. Supports ISO8601 date range filters.
       parameters:
-        - name: id
+        - name: space
           in: path
-          required: true
+          required: false
           schema:
             type: string
         - name: since


### PR DESCRIPTION
This makes a few minor changes to make the /api/reports/storage/spaces endpoint not require a space ID but run the report on whole database if none is given.