### PR TITLE
Move file between folders reindex bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+- Files were not properly reindexed when the Move button was used to move a file into or out of a folder in a dataset. 
+  This has been fixed.
+
 ## 1.14.0 - 2021-01-07
 
 ### Added

--- a/app/api/Folders.scala
+++ b/app/api/Folders.scala
@@ -302,6 +302,8 @@ class Folders @Inject() (
                           if(oldFolder.files.contains(fileId)) {
                             folders.removeFile(oldFolder.id, fileId)
                             folders.addFile(newFolder.id, fileId)
+                            files.index(fileId)
+                            datasets.index(datasetId)
                             Ok(toJson(Map("status" -> "success", "fileName" -> file.filename, "folderName" -> newFolder.name)))
                           } else {
                             BadRequest("Failed to move file. The file with id: " + file.id.stringify + " isn't in folder with id: " + oldFolder.id.stringify  )
@@ -315,6 +317,8 @@ class Folders @Inject() (
                       if(dataset.files.contains(fileId)) {
                         folders.addFile(newFolder.id, fileId)
                         datasets.removeFile(datasetId, fileId)
+                        files.index(fileId)
+                        datasets.index(datasetId)
                         Ok(toJson(Map("status" -> "success", "fileName" -> file.filename, "folderName" -> newFolder.name)))
                       } else {
                         BadRequest("Failed to move file. The file with id: " + file.id.stringify + "Isn't in dataset with id: " + dataset.id.stringify  )
@@ -353,6 +357,8 @@ class Folders @Inject() (
                 if(folder.files.contains(fileId)) {
                   datasets.addFile(datasetId, file)
                   folders.removeFile(oldFolderId, fileId)
+                  files.index(fileId)
+                  datasets.index(datasetId)
                   Ok(toJson(Map("status" -> "success", "fileName"-> file.filename )))
                 } else {
                   BadRequest("The file you are trying to move isn't in the folder you are moving it from.")


### PR DESCRIPTION
When moving a file into a folder or out of it, the dataset and file were not reindexed so searches using the ?folderid= parameter would break. This adds reindex calls so the search stays in sync. 

In the meantime, manually POSTing to /api/files/:id/reindex and /api/datasets/:id/reindex should fix the affected searches.