### PR TITLE
When adding a file to a dataset by URL, prioritize the URL `content-type` header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+- When adding a file to a dataset by URL, prioritize the URL `content-type` header over the file content type established
+  by looking at the file name extension.
+
 ## 1.14.0 - 2021-01-07
 
 ### Added

--- a/app/util/FileUtils.scala
+++ b/app/util/FileUtils.scala
@@ -661,12 +661,18 @@ object FileUtils {
       case Some((loader_id, loader, length)) => {
         files.get(file.id) match {
           case Some(f) => {
-            val fixedfile = f.copy(contentType=conn.getContentType, loader=loader, loader_id=loader_id, length=length)
-            files.save(fixedfile)
+            // if header's content type is application/octet-stream leave content type as the one based on file name,
+            // otherwise replace with value from header.
+            val fixedFile = if (conn.getContentType == play.api.http.ContentTypes.BINARY) {
+              f.copy(loader = loader, loader_id = loader_id, length = length)
+            } else {
+              f.copy(contentType = conn.getContentType, loader = loader, loader_id = loader_id, length = length)
+            }
+            files.save(fixedFile)
             appConfig.incrementCount('files, 1)
             appConfig.incrementCount('bytes, f.length)
             Logger.debug("Uploading Completed")
-            Some(fixedfile)
+            Some(fixedFile)
           }
           case None => {
             Logger.error(s"File $loader_id was not found anymore")


### PR DESCRIPTION
over the file content type established by looking at the file name extension.

This is related to https://github.com/clowder-framework/clowder/issues/139. We are not sure it fixes that problems all together but it is an improvement over the current behaviour.