### PR TITLE
Release/1.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+Google will no longer work as login provider, we are working on this issue #157.
+
+If non local accounts are used the count can be wrong. Use the [fixcounts](https://github.com/clowder-framework/clowder/blob/develop/scripts/updates/fix-counts.js)
+script to fix this.
+
 ### Fixed
+- Error logging in with orcid due to changed URL #91
+- Fixed error in url for twitter login
+- Count of users is not correct if using anything else but local accounts #136
 - Files were not properly reindexed when the Move button was used to move a file into or out of a folder in a dataset. 
-  This has been fixed.
 - When adding a file to a dataset by URL, prioritize the URL `content-type` header over the file content type established
   by looking at the file name extension.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+- When adding a file to a dataset by URL, prioritize the URL `content-type` header over the file content type established
+  by looking at the file name extension.
+
 ## 1.14.0 - 2021-01-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+## 1.14.1 - 2021-02-02
 
-Google will no longer work as login provider, we are working on this issue #157.
-
-If non local accounts are used the count can be wrong. Use the [fixcounts](https://github.com/clowder-framework/clowder/blob/develop/scripts/updates/fix-counts.js)
+- Google will no longer work as login provider, we are working on this issue [#157](https://github.com/clowder-framework/clowder/issues/157).
+- If non local accounts are used the count can be wrong. Use the [fixcounts](https://github.com/clowder-framework/clowder/blob/develop/scripts/updates/fix-counts.js)
 script to fix this.
 
 ### Fixed
-- Error logging in with orcid due to changed URL #91
-- Fixed error in url for twitter login
-- Count of users is not correct if using anything else but local accounts #136
+- Error logging in with Orcid due to changed URL. [#91](https://github.com/clowder-framework/clowder/issues/91)
+- Fixed error in url for Twitter login.
+- Users count was not correct if using anything else but local accounts. [#136](https://github.com/clowder-framework/clowder/issues/136)
 - Files were not properly reindexed when the Move button was used to move a file into or out of a folder in a dataset. 
 - When adding a file to a dataset by URL, prioritize the URL `content-type` header over the file content type established
-  by looking at the file name extension.
+  by looking at the file name extension. [#139](https://github.com/clowder-framework/clowder/issues/139)
 - Wrap words across lines to stay within interface elements. [#160](https://github.com/clowder-framework/clowder/issues/160)
 
 ## 1.14.0 - 2021-01-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - `api/reports/storage/spaces` endpoint now accepts a space parameter for ID rather than requiring a space filter.
 - Datasets and collections in the trash are no longer indexed for discovery in search services.
+- Switched to loading the 3DHOP libraries used by `viewer_hop.js` from http://vcg.isti.cnr.it/3dhop/distribution to https://3dhop.net/distribution. The new server is a safer https server.
 
 ## 1.13.0 - 2020-12-02
 
@@ -68,8 +69,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Track user_id with every extraction event. [#94](https://github.com/clowder-framework/clowder/issues/94)
 - Added a new storage report at `GET api/reports/storage/spaces/:id` for auditing user storage usage on a space basis.
 - The file and dataset metrics reports also have support for since and until ISO8601 date parameters.
-- Added `viewer_hop` a 3D models previewer for `*.ply` and `*.nxz` files. Added `mimetype.nxz=model/nxz` and 
-  `mimetype.NXZ=model/nxz` as new mimetypes in `conf/mimetypes.conf`
+- Added `viewer_hop` a 3D models previewer for `*.ply` and `*.nxz` files. Added `mimetype.nxz=model/nxz` and `mimetype.NXZ=model/nxz` as new mimetypes in `conf/mimetypes.conf`
 
 ### Fixed
 - Ignore the `update` field when posting to `/api/extractors`. [#89](https://github.com/clowder-framework/clowder/issues/89)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ### Fixed
+- Files were not properly reindexed when the Move button was used to move a file into or out of a folder in a dataset. 
+  This has been fixed.
 - When adding a file to a dataset by URL, prioritize the URL `content-type` header over the file content type established
   by looking at the file name extension.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ script to fix this.
 - Files were not properly reindexed when the Move button was used to move a file into or out of a folder in a dataset. 
 - When adding a file to a dataset by URL, prioritize the URL `content-type` header over the file content type established
   by looking at the file name extension.
+- Wrap words across lines to stay within interface elements. [#160](https://github.com/clowder-framework/clowder/issues/160)
 
 ## 1.14.0 - 2021-01-07
 

--- a/app/api/Folders.scala
+++ b/app/api/Folders.scala
@@ -302,6 +302,8 @@ class Folders @Inject() (
                           if(oldFolder.files.contains(fileId)) {
                             folders.removeFile(oldFolder.id, fileId)
                             folders.addFile(newFolder.id, fileId)
+                            files.index(fileId)
+                            datasets.index(datasetId)
                             Ok(toJson(Map("status" -> "success", "fileName" -> file.filename, "folderName" -> newFolder.name)))
                           } else {
                             BadRequest("Failed to move file. The file with id: " + file.id.stringify + " isn't in folder with id: " + oldFolder.id.stringify  )
@@ -315,6 +317,8 @@ class Folders @Inject() (
                       if(dataset.files.contains(fileId)) {
                         folders.addFile(newFolder.id, fileId)
                         datasets.removeFile(datasetId, fileId)
+                        files.index(fileId)
+                        datasets.index(datasetId)
                         Ok(toJson(Map("status" -> "success", "fileName" -> file.filename, "folderName" -> newFolder.name)))
                       } else {
                         BadRequest("Failed to move file. The file with id: " + file.id.stringify + "Isn't in dataset with id: " + dataset.id.stringify  )
@@ -353,6 +357,8 @@ class Folders @Inject() (
                 if(folder.files.contains(fileId)) {
                   datasets.addFile(datasetId, file)
                   folders.removeFile(oldFolderId, fileId)
+                  files.index(fileId)
+                  datasets.index(datasetId)
                   Ok(toJson(Map("status" -> "success", "fileName"-> file.filename )))
                 } else {
                   BadRequest("The file you are trying to move isn't in the folder you are moving it from.")

--- a/app/util/FileUtils.scala
+++ b/app/util/FileUtils.scala
@@ -661,12 +661,18 @@ object FileUtils {
       case Some((loader_id, loader, length)) => {
         files.get(file.id) match {
           case Some(f) => {
-            val fixedfile = f.copy(contentType=conn.getContentType, loader=loader, loader_id=loader_id, length=length)
-            files.save(fixedfile)
+            // if header's content type is application/octet-stream leave content type as the one based on file name,
+            // otherwise replace with value from header.
+            val fixedFile = if (conn.getContentType == play.api.http.ContentTypes.BINARY) {
+              f.copy(loader = loader, loader_id = loader_id, length = length)
+            } else {
+              f.copy(contentType = conn.getContentType, loader = loader, loader_id = loader_id, length = length)
+            }
+            files.save(fixedFile)
             appConfig.incrementCount('files, 1)
             appConfig.incrementCount('bytes, f.length)
             Logger.debug("Uploading Completed")
-            Some(fixedfile)
+            Some(fixedFile)
           }
           case None => {
             Logger.error(s"File $loader_id was not found anymore")

--- a/app/views/collectionofdatasets.scala.html
+++ b/app/views/collectionofdatasets.scala.html
@@ -89,7 +89,7 @@
 
 				</ol>
 				<div class="col-xs-12 collection-title" id="coll-title">
-					<h1 id ="collectiontitle" class="inline"><span class="glyphicon glyphicon-th-large"></span> @Html(collection.name)</h1>
+					<h1 id ="collectiontitle" class="inline break-word"><span class="glyphicon glyphicon-th-large"></span> @Html(collection.name)</h1>
 					@if(!collection.trash && Permission.checkPermission(Permission.EditCollection, ResourceRef(ResourceRef.collection, collection.id))) {
 						<h3 id="h-edit-title" class="hiddencomplete">
 							<a id="edit-title" href="javascript:updateTitle()" edit="Click to edit title">

--- a/app/views/datasets/listitem.scala.html
+++ b/app/views/datasets/listitem.scala.html
@@ -29,7 +29,7 @@
                     <div class="col-md-8 col-lg-8 col-sm-8">
                         <div class="row">
                             <div class="col-xs-12">
-                                <span class="h2"><a href="@(routes.Datasets.dataset(dataset.id))">@Html(dataset.name)</a></span>
+                                <span class="h2"><a href="@(routes.Datasets.dataset(dataset.id))" class="break-word">@Html(dataset.name)</a></span>
                             </div>
                         </div>
                         <div class="row">

--- a/app/views/file.scala.html
+++ b/app/views/file.scala.html
@@ -257,7 +257,7 @@
 			<div class="row">
 				<div id="file-name-div" class="file-title-div col-xs-12">
 					<div id="prf-file-name" class="text-left inline">
-						<h1 id="file-name-title" class="inline"> <span class="glyphicon glyphicon-file"></span> @Html(file.filename)</h1>
+						<h1 id="file-name-title" class="inline break-word"> <span class="glyphicon glyphicon-file"></span> @Html(file.filename)</h1>
 						@if(Permission.checkPermission(Permission.EditFile, ResourceRef(ResourceRef.file, file.id))) {
 							<div id="h-edit-file" class="hiddencomplete">
 								<a id ="edit-file" href="javascript:updateFileName()" title="Click to edit file name.">

--- a/app/views/files/linkDownload.scala.html
+++ b/app/views/files/linkDownload.scala.html
@@ -3,7 +3,7 @@
 @main("Download File") {
     <div class="row">
         <div class="col-md-12">
-            <h1 id="file-name-title" class="inline"><span class="glyphicon glyphicon-file"></span> @Html(file.filename)</h1>
+            <h1 id="file-name-title" class="inline break-word"><span class="glyphicon glyphicon-file"></span> @Html(file.filename)</h1>
         </div>
     </div>
     <div class="row">

--- a/app/views/files/listitem.scala.html
+++ b/app/views/files/listitem.scala.html
@@ -23,7 +23,7 @@
             </div>
 
             <div class="col-md-10 col-sm-10 col-lg-10">
-                <h3><a href="@(routes.Files.file(file.id, dataset, space, folder))">@file.filename</a></h3>
+                <h3><a href="@(routes.Files.file(file.id, dataset, space, folder))" class="break-word">@file.filename</a></h3>
                 <div class="row">
                     <div class="col-md-8 col-lg-8 col-sm-8">
                         <ul class="list-unstyled">

--- a/app/views/files/share.scala.html
+++ b/app/views/files/share.scala.html
@@ -3,7 +3,7 @@
 @main("Share") {
     <div class="row">
         <div class="col-md-12">
-            <h1 id="file-name-title" class="inline"><span class="glyphicon glyphicon-file"></span> @Html(file.filename)</h1>
+            <h1 id="file-name-title" class="inline  break-word"><span class="glyphicon glyphicon-file"></span> @Html(file.filename)</h1>
         </div>
     </div>
     <div class="row">

--- a/app/views/spaces/spaceAllocation.scala.html
+++ b/app/views/spaces/spaceAllocation.scala.html
@@ -37,7 +37,7 @@
                 </div>
                 <div class="col-md-10">
                     <div>
-                        <a href="@routes.Spaces.getSpace(s.id)" id='@s.id' class ="space">@s.name</a>
+                        <a href="@routes.Spaces.getSpace(s.id)" id='@s.id' class ="space-title">@s.name</a>
                     </div>
                     <div>
                         @if(resourceType == ResourceRef.dataset) {

--- a/conf/messages
+++ b/conf/messages
@@ -12,7 +12,7 @@ trial.title = Trial {0}
 owner.label=Owner
 owner.title = {0}''s {1}
 owner.in.resource.title={0}''s {1} in {2}  <a href="{3}">{4}</a>
-resource.in.title= {0} in {1} <a href="{2}">{3}</a>
+resource.in.title= {0} in {1} <a href="{2}" class="break-word">{3}</a>
 list.title= {0}
 
 # Basic terms

--- a/conf/securesocial.conf
+++ b/conf/securesocial.conf
@@ -79,9 +79,9 @@ securesocial {
     ssl=false
 
     twitter {
-        requestTokenUrl="https://twitter.com/oauth/request_token"
-        accessTokenUrl="https://twitter.com/oauth/access_token"
-        authorizationUrl="https://twitter.com/oauth/authenticate"
+        requestTokenUrl="https://api.twitter.com/oauth/request_token"
+        accessTokenUrl="https://api.twitter.com/oauth/access_token"
+        authorizationUrl="https://api.twitter.com/oauth/authorize"
         consumerKey=your_consumer_key
         consumerSecret=your_consumer_secret
     }
@@ -135,7 +135,7 @@ securesocial {
 
     orcid {
         authorizationUrl="https://orcid.org/oauth/authorize"
-        accessTokenUrl="https://pub.orcid.org/oauth/token"
+        accessTokenUrl="https://orcid.org/oauth/token"
         clientId=your_client_id
         clientSecret=your_client_secret
         scope="/authenticate"

--- a/doc/src/sphinx/conf.py
+++ b/doc/src/sphinx/conf.py
@@ -22,7 +22,7 @@ copyright = '2019, University of Illinois at Urbana-Champaign'
 author = 'Luigi Marini'
 
 # The full version, including alpha/beta/rc tags
-release = '1.14.0'
+release = '1.14.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -13,7 +13,7 @@ import NativePackagerKeys._
 object ApplicationBuild extends Build {
 
   val appName = "clowder"
-  val version = "1.14.0"
+  val version = "1.14.1"
   val jvm = "1.7"
 
   def appVersion: String = {

--- a/public/javascripts/previewers/viewer_hop/viewer_hop.js
+++ b/public/javascripts/previewers/viewer_hop/viewer_hop.js
@@ -3,7 +3,7 @@
 
   Loads the 3DHOP library and uses methods and functions to 
   load 3D models in point cloud (*.ply) and nexus (*.nxz) form
-   into a clowder repository.   
+  into a clowder repository.   
  
   Language: JavaScript
   
@@ -13,19 +13,21 @@
   + 09/14/20 (cc): Created.
   + 10/14/20 (cc): Changing the source of the 3DHOP files
                    and load them online
+  + 01/08/21 (cc): Loading libraries from https
 
 ****************************************************************/
 
-(function ($, Configuration) {
-  var useTab = Configuration.tab;
-  var referenceUrl = Configuration.url;
-  var confId = Configuration.id;
-  var fileId = Configuration.fileid;
-  var previewer = Configuration.previewer;
 
-  var fileName = $('#file-name-title').text().trim();
-  var fileNameExtension = fileName.substr(fileName.length - 3);
-  var fileType;
+(function ($, Configuration) {
+  let useTab = Configuration.tab;
+  let referenceUrl = Configuration.url;
+  let confId = Configuration.id;
+  let fileId = Configuration.fileid;
+  let previewer = Configuration.previewer;
+
+  let fileName = $('#file-name-title').text().trim();
+  let fileNameExtension = fileName.substr(fileName.length - 3);
+  let fileType;
 
   if (fileNameExtension == "ply") {
     fileType = "ply";
@@ -33,11 +35,6 @@
   else if (fileNameExtension == "nxz") {
     fileType = "nexus";
   }
-
-  //alert(fileName);
-  //alert(typeof(fileName));
-  //alert(fileNameExtension);
-  //alert(fileType);
 
   // print all attributes of Configuration object
 
@@ -48,7 +45,7 @@
 
   // add 3dhop.css to previewer
 
-  $(useTab).append('<link rel="stylesheet" type="text/css" href="http://vcg.isti.cnr.it/3dhop/distribution/stylesheet/3dhop.css">');
+  $(useTab).append('<link rel="stylesheet" type="text/css" href = "https://3dhop.net/distribution/latest/stylesheet/3dhop.css">');
 
   // load various 3dhop attributes (such as the background image) for 3dhop
 
@@ -66,22 +63,22 @@
     id: 'toolbar'
   }));
 
-  $("#toolbar").append("<img id='home' title='Home'  src='http://vcg.isti.cnr.it/3dhop/distribution/skins/dark/home.png'/><br/>");
+  $("#toolbar").append("<img id='home' title='Home'  src='https://3dhop.net/distribution/latest/skins/dark/home.png'/><br/>");
 
-  $("#toolbar").append("<img id='zoomin' title='Zoom In'  src='http://vcg.isti.cnr.it/3dhop/distribution/skins/dark/zoomin.png'/><br/>");
-  $("#toolbar").append("<img id='zoomout' title='Zoom Out'  src='http://vcg.isti.cnr.it/3dhop/distribution/skins/dark/zoomout.png'/><br/>");
+  $("#toolbar").append("<img id='zoomin' title='Zoom In'  src='https://3dhop.net/distribution/latest/skins/dark/zoomin.png'/><br/>");
+  $("#toolbar").append("<img id='zoomout' title='Zoom Out'  src='https://3dhop.net/distribution/latest/skins/dark/zoomout.png'/><br/>");
 
-  $("#toolbar").append("<img id='light_on' title='Disable Light Control'  src='http://vcg.isti.cnr.it/3dhop/distribution/skins/dark/lightcontrol_on.png' style='position:absolute; visibility:hidden;'/>");
-  $("#toolbar").append("<img id='light' title='Enable Light Control'  src='http://vcg.isti.cnr.it/3dhop/distribution/skins/dark/lightcontrol.png'/><br/>");
+  $("#toolbar").append("<img id='light_on' title='Disable Light Control'  src='https://3dhop.net/distribution/latest/skins/dark/lightcontrol_on.png' style='position:absolute; visibility:hidden;'/>");
+  $("#toolbar").append("<img id='light' title='Enable Light Control'  src='https://3dhop.net/distribution/latest/skins/dark/lightcontrol.png'/><br/>");
 
-  $("#toolbar").append("<img id='measure_on' title='Disable Measure Tool'  src='http://vcg.isti.cnr.it/3dhop/distribution/skins/dark/measure_on.png' style='position:absolute; visibility:hidden;'/>");
-  $("#toolbar").append("<img id='measure' title='Enable Measure Tool'  src='http://vcg.isti.cnr.it/3dhop/distribution/skins/dark/measure.png'/><br/>");
+  $("#toolbar").append("<img id='measure_on' title='Disable Measure Tool'  src='https://3dhop.net/distribution/latest/skins/dark/measure_on.png' style='position:absolute; visibility:hidden;'/>");
+  $("#toolbar").append("<img id='measure' title='Enable Measure Tool'  src='https://3dhop.net/distribution/latest/skins/dark/measure.png'/><br/>");
 
-  $("#toolbar").append("<img id='pick_on' title='Disable PickPoint Mode'  src='http://vcg.isti.cnr.it/3dhop/distribution/skins/dark/pick_on.png' style='position:absolute; visibility:hidden;'/>");
-  $("#toolbar").append("<img id='pick' title='Enable PickPoint Mode'  src='http://vcg.isti.cnr.it/3dhop/distribution/skins/dark/pick.png'/><br/>");
+  $("#toolbar").append("<img id='pick_on' title='Disable PickPoint Mode'  src='https://3dhop.net/distribution/latest/skins/dark/pick_on.png' style='position:absolute; visibility:hidden;'/>");
+  $("#toolbar").append("<img id='pick' title='Enable PickPoint Mode'  src='https://3dhop.net/distribution/latest/skins/dark/pick.png'/><br/>");
 
-  $("#toolbar").append("<img id='full_on' title='Exit Full Screen'  src='http://vcg.isti.cnr.it/3dhop/distribution/skins/dark/full_on.png' style='position:absolute; visibility:hidden;'/>");
-  $("#toolbar").append("<img id='full' title='Full Screen'  src='http://vcg.isti.cnr.it/3dhop/distribution/skins/dark/full.png'/>");
+  $("#toolbar").append("<img id='full_on' title='Exit Full Screen'  src='https://3dhop.net/distribution/latest/skins/dark/full_on.png' style='position:absolute; visibility:hidden;'/>");
+  $("#toolbar").append("<img id='full' title='Full Screen'  src='https://3dhop.net/distribution/latest/skins/dark/full.png'/>");
 
   $('#3dhop').append($('<div/>', {
     id: 'measure-box',
@@ -119,18 +116,18 @@
 
   $("#3dhop").append($('<canvas/>', {
     id: 'draw-canvas',
-    style: 'background-image: url("http://vcg.isti.cnr.it/3dhop/distribution/skins/backgrounds/dark.jpg")'
+    style: 'background-image: url("https://3dhop.net/distribution/latest/skins/backgrounds/dark.jpg")'
   }));
 
   // scripts  holds all the  3dhop files                                                                        
 
-  var scripts = ["spidergl.js", "nexus.js", "ply.js", "trackball_sphere.js",
+  let scripts = ["spidergl.js", "nexus.js", "ply.js", "trackball_sphere.js",
     "trackball_turntable.js", "trackball_pantilt.js", "trackball_turntable_pan.js", "init.js", "presenter.js"];
 
   // append the http address where the files are located
 
   for (index = 0; index < scripts.length; index++) {
-    scripts[index] = "http://vcg.isti.cnr.it/3dhop/distribution/js/" + scripts[index];
+    scripts[index] = "https://3dhop.net/distribution/latest/js/" + scripts[index];
   }
 
   // load 3dhop into the current tab   (old version)                                                                         
@@ -189,7 +186,7 @@
 
 function getScripts(scripts, callback) {
 
-  var progress = 0;
+  let progress = 0;
 
   scripts.forEach(function (script) {
     //alert(script);
@@ -199,7 +196,7 @@ function getScripts(scripts, callback) {
   });
 }
 
-var presenter = null;
+let presenter = null;
 
 function setup3dhop(address, fileType) {
   presenter = new Presenter("draw-canvas");

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -579,6 +579,10 @@ p.error, span.error {
 	border-bottom: 1px solid #E1E1E8;
 }
 
+.space-title {
+	word-wrap: break-word;
+}
+
 .space-col-right {
 	padding-left: 50px;
 }

--- a/public/swagger.yml
+++ b/public/swagger.yml
@@ -9,7 +9,7 @@ info:
     Clowder is a customizable and scalable data management system to support any
     data format and multiple research domains. It is under active development
     and deployed for a variety of research projects.
-  version: 1.14.0
+  version: 1.14.1
   termsOfService: https://clowder.ncsa.illinois.edu/clowder/tos
   contact:
     name: Clowder


### PR DESCRIPTION
## 1.14.1 - 2021-02-02

- Google will no longer work as login provider, we are working on this issue [#157](https://github.com/clowder-framework/clowder/issues/157).
- If non local accounts are used the count can be wrong. Use the [fixcounts](https://github.com/clowder-framework/clowder/blob/develop/scripts/updates/fix-counts.js)
script to fix this.

### Fixed
- Error logging in with Orcid due to changed URL. [#91](https://github.com/clowder-framework/clowder/issues/91)
- Fixed error in url for Twitter login.
- Users count was not correct if using anything else but local accounts. [#136](https://github.com/clowder-framework/clowder/issues/136)
- Files were not properly reindexed when the Move button was used to move a file into or out of a folder in a dataset. 
- When adding a file to a dataset by URL, prioritize the URL `content-type` header over the file content type established
  by looking at the file name extension. [#139](https://github.com/clowder-framework/clowder/issues/139)
- Wrap words across lines to stay within interface elements. [#160](https://github.com/clowder-framework/clowder/issues/160)