### PR TITLE
Add events for user login and signup to EventSinkService

### DIFF
--- a/app/services/EventSinkService.scala
+++ b/app/services/EventSinkService.scala
@@ -27,7 +27,7 @@ class EventSinkService {
   val userService: UserService = DI.injector.getInstance(classOf[UserService])
   val appConfig: AppConfigurationService = DI.injector.getInstance(classOf[AppConfigurationService])
 
-  // Fetch directly from config on demand
+  // UNUSED: Fetch directly from config on demand
   def getGoogleAnalytics(): String = Play.configuration.getString(EventSinkService.GA_CONFIG_KEY).getOrElse("")
   def getAmplitudeApiKey(): String = Play.configuration.getString(EventSinkService.AMPLITUDE_CONFIG_KEY).getOrElse("")
   def getMongoAuth(): String = Play.configuration.getString(EventSinkService.AMPLITUDE_CONFIG_KEY).getOrElse("")
@@ -51,14 +51,23 @@ class EventSinkService {
     messageService.submit(exchangeName, queueName, metadata, "fanout")
   }
 
-  // TODO: Call this when admin changes configuration via the UI
-  def syncAuthInfo() = {
-    Logger.info("Synchronizing event sink consumer auth")
-    logEvent("auth_sync", Json.obj(
-      "amplitude" -> getAmplitudeApiKey(),
-      "google_analytics" -> getGoogleAnalytics(),
-      "influx" -> getInfluxAuth(),
-      "mongo" -> getMongoAuth()
+  /** Log an event when user signs up */
+  def logUserSignupEvent(user: User) = {
+    Logger.info("New user signed up: " + user.id.stringify)
+    logEvent("user_activity", Json.obj(
+      "type" -> "signup",
+      "user_id" -> user.id,
+      "user_name" -> user.fullName
+    ))
+  }
+
+  /** Log an event when user logs in */
+  def logUserLoginEvent(user: User) = {
+    Logger.info("User logged in: " + user.id.stringify)
+    logEvent("user_activity", Json.obj(
+      "type" -> "login",
+      "user_id" -> user.id,
+      "user_name" -> user.fullName
     ))
   }
 

--- a/app/services/SecureSocialEventListener.scala
+++ b/app/services/SecureSocialEventListener.scala
@@ -12,6 +12,7 @@ class SecureSocialEventListener(app: play.api.Application) extends EventListener
   override def id: String = "SecureSocialEventListener"
   lazy val userService: UserService = DI.injector.getInstance(classOf[UserService])
   lazy val spaceService: SpaceService = DI.injector.getInstance(classOf[SpaceService])
+  lazy val sinkService: EventSinkService = DI.injector.getInstance(classOf[EventSinkService])
   lazy val appConfig: AppConfigurationService = DI.injector.getInstance(classOf[AppConfigurationService])
 
   def onEvent(event: Event, request: RequestHeader, session: Session): Option[Session] = {
@@ -27,6 +28,7 @@ class SecureSocialEventListener(app: play.api.Application) extends EventListener
               case None => Logger.debug("No email found for user "+user.id.stringify)
             }
             userService.updateUserField(user.id, "lastLogin", new Date())
+            sinkService.logUserSignupEvent(user)
           }
           case None => {
             Logger.error(s"Could not find user ${event.user.fullName} in database")
@@ -47,6 +49,7 @@ class SecureSocialEventListener(app: play.api.Application) extends EventListener
               case None => Logger.debug("No email found for user "+user.id.stringify)
             }
             userService.updateUserField(user.id, "lastLogin", new Date())
+            sinkService.logUserLoginEvent(user)
           }
           case None => {
             Logger.error(s"Could not find user ${event.user.fullName} in database")


### PR DESCRIPTION
## Description
### Problem
We do not currently capture events in Grafana for user login and signup.

### Approach
* Leverage the event sink service to quickly log new signups / logins as events

Long-term, it might be nice to look into the [MongoDB Datasource Plugin for Grafana](https://grafana.com/grafana/plugins/grafana-mongodb-datasource)

### How to Test
1. Checkout and run this branch locally
2. Login to Clowder
    * You should see a message in the logs saying something like `Submitting message to event sink exchange: {"type":"login","user_id":"5f0e55c2d7442415d335a181","user_name":"Mike Lambert"}`
3. Signup/register a new user and you should instead see `"type": "signup"`

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [x] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have signed the CLA
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
