### PR TITLE
Release/1.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   Replaced `get()` with `getOrElse()`.
 - Consolidated field names sent by the EventSinkService to maximize reuse.
 - Changed `EventSinkService` logging to debug to minimize chatter.
+- Don't automatically create eventsink queue and bind it to eventsink exchange. Let clients do that so that we don't 
+  have a queue for the eventsink filling up if there are no consumers.
 
 ## 1.15.0 - 2021-03-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.15.1 - 2021-03-12
+
+### Fixed
+- Several views were throwing errors trying to access a None value in `EventSinkService` when a user was not logged in. 
+  Replaced `get()` with `getOrElse()`.
+
 ## 1.15.0 - 2021-03-03
 
 ### Added

--- a/app/services/EventSinkService.scala
+++ b/app/services/EventSinkService.scala
@@ -80,8 +80,8 @@ class EventSinkService {
       "resource_name" -> dataset.name,
       "author_id" -> dataset.author.id,
       "author_name" -> dataset.author.fullName,
-      "viewer_id" -> viewer.get.id,
-      "viewer_name" -> viewer.get.getMiniUser.fullName
+      "viewer_id" -> viewer.getOrElse(User.anonymous).id,
+      "viewer_name" -> viewer.getOrElse(User.anonymous).getMiniUser.fullName
     ))
   }
 
@@ -94,8 +94,8 @@ class EventSinkService {
       "resource_name" -> file.filename,
       "author_id" -> file.author.id,
       "author_name" -> file.author.fullName,
-      "viewer_id" -> viewer.get.id,
-      "viewer_name" -> viewer.get.getMiniUser.fullName
+      "viewer_id" -> viewer.getOrElse(User.anonymous).id,
+      "viewer_name" -> viewer.getOrElse(User.anonymous).getMiniUser.fullName
     ))
   }
 
@@ -108,8 +108,8 @@ class EventSinkService {
       "resource_name" -> collection.name,
       "author_id" -> collection.author.id,
       "author_name" -> collection.author.fullName,
-      "viewer_id" -> viewer.get.id,
-      "viewer_name" -> viewer.get.getMiniUser.fullName
+      "viewer_id" -> viewer.getOrElse(User.anonymous).id,
+      "viewer_name" -> viewer.getOrElse(User.anonymous).getMiniUser.fullName
     ))
   }
 
@@ -135,8 +135,8 @@ class EventSinkService {
           "resource_name" -> space.name,
           "author_id" -> author.id,
           "author_name" -> author.fullName,
-          "viewer_id" -> "",
-          "viewer_name" -> "Anonymous"
+          "viewer_id" -> User.anonymous.id,
+          "viewer_name" -> User.anonymous.fullName
         ))
       }
       case (Some(v), None) => {
@@ -159,8 +159,8 @@ class EventSinkService {
           "resource_name" -> space.name,
           "author_id" -> space.creator.stringify,
           "author_name" -> "",
-          "viewer_id" -> "",
-          "viewer_name" -> "Anonymous"
+          "viewer_id" -> User.anonymous.id,
+          "viewer_name" -> User.anonymous.fullName
         ))
       }
     }
@@ -174,8 +174,8 @@ class EventSinkService {
       "resource_name" -> file.filename,
       "author_id" -> file.author.id,
       "author_name" -> file.author.fullName,
-      "submitter_id" -> submitter.get.id,
-      "submitter_name" -> submitter.get.getMiniUser.fullName
+      "submitter_id" -> submitter.getOrElse(User.anonymous).id,
+      "submitter_name" -> submitter.getOrElse(User.anonymous).getMiniUser.fullName
     ))
   }
 
@@ -187,8 +187,8 @@ class EventSinkService {
       "resource_name" -> dataset.name,
       "author_id" -> dataset.author.id,
       "author_name" -> dataset.author.fullName,
-      "submitter_id" -> submitter.get.id,
-      "submitter_name" -> submitter.get.getMiniUser.fullName
+      "submitter_id" -> submitter.getOrElse(User.anonymous).id,
+      "submitter_name" -> submitter.getOrElse(User.anonymous).getMiniUser.fullName
     ))
   }
 
@@ -201,8 +201,8 @@ class EventSinkService {
       "resource_name" -> dataset.name,
       "author_id" -> dataset.author.id,
       "author_name" -> dataset.author.fullName,
-      "submitter_id" -> submitter.get.id,
-      "submitter_name" -> submitter.get.getMiniUser.fullName
+      "submitter_id" -> submitter.getOrElse(User.anonymous).id,
+      "submitter_name" -> submitter.getOrElse(User.anonymous).getMiniUser.fullName
     ))
   }
 
@@ -214,16 +214,16 @@ class EventSinkService {
           "dataset_name" -> d.name,
           "dataset_author_name" -> d.author.fullName,
           "dataset_author_id" -> d.author.id,
-          "uploader_id" -> uploader.get.id,
-          "uploader_name" -> uploader.get.getMiniUser.fullName,
+          "uploader_id" -> uploader.getOrElse(User.anonymous).id,
+          "uploader_name" -> uploader.getOrElse(User.anonymous).getMiniUser.fullName,
           "filename" -> file.filename,
           "length" -> file.length
         ))
       }
       case None => {
         logEvent("upload", Json.obj(
-          "uploader_id" -> uploader.get.id,
-          "uploader_name" -> uploader.get.getMiniUser.fullName,
+          "uploader_id" -> uploader.getOrElse(User.anonymous).id,
+          "uploader_name" -> uploader.getOrElse(User.anonymous).getMiniUser.fullName,
           "filename" -> file.filename,
           "length" -> file.length
         ))
@@ -240,8 +240,8 @@ class EventSinkService {
       "type" -> "file",
       "uploader_id" -> file.author.id,
       "uploader_name" -> file.author.fullName,
-      "downloader_id" -> downloader.get.id,
-      "downloader_name" -> downloader.get.getMiniUser.fullName,
+      "downloader_id" -> downloader.getOrElse(User.anonymous).id,
+      "downloader_name" -> downloader.getOrElse(User.anonymous).getMiniUser.fullName,
       "filename" -> file.filename,
       "length" -> file.length
     ))
@@ -254,8 +254,8 @@ class EventSinkService {
       "dataset_name" -> dataset.name,
       "dataset_author_name" -> dataset.author.fullName,
       "dataset_author_id" -> dataset.author.id,
-      "downloader_id" -> downloader.get.id,
-      "downloader_name" -> downloader.get.getMiniUser.fullName,
+      "downloader_id" -> downloader.getOrElse(User.anonymous).id,
+      "downloader_name" -> downloader.getOrElse(User.anonymous).getMiniUser.fullName,
       "files_length" -> dataset.files.length,
       "folder_length" -> dataset.folders.length
     ))

--- a/app/services/EventSinkService.scala
+++ b/app/services/EventSinkService.scala
@@ -33,7 +33,11 @@ class EventSinkService {
     // Inject timestamp before logging the event
     val event = message.as[JsObject] + ("created" -> Json.toJson(java.util.Date.from(Instant.now())))
     Logger.info("Submitting message to event sink exchange: " + Json.stringify(event))
-    messageService.submit(exchangeName, queueName, event, "fanout")
+    try {
+      messageService.submit(exchangeName, queueName, event, "fanout")
+    } catch {
+      case e: Throwable => { Logger.error("Failed to submit event sink message", e) }
+    }
   }
 
   /** Log an event when user signs up */

--- a/app/services/EventSinkService.scala
+++ b/app/services/EventSinkService.scala
@@ -13,7 +13,7 @@ object EventSinkService {
   val QUEUE_NAME_CONFIG_KEY = "eventsink.queuename"
 
   val EXCHANGE_NAME_DEFAULT_VALUE = "clowder.metrics"
-  val QUEUE_NAME_DEFAULT_VALUE = "event.sink"
+  val QUEUE_NAME_DEFAULT_VALUE = ""
 }
 
 class EventSinkService {

--- a/app/services/rabbitmq/RabbitMQMessageService.scala
+++ b/app/services/rabbitmq/RabbitMQMessageService.scala
@@ -233,6 +233,12 @@ class RabbitMQMessageService extends MessageService {
     // This probably isn't going to extract queue (use other submit() for that) so make a new broker
     val tempChannel = connection.get.createChannel()
     tempChannel.exchangeDeclare(exchange, exchange_type, true)
+    
+    // If a routing_key (queue name) was provided, ensure that the queue exists
+    if (routing_key != "") {
+      tempChannel.queueDeclare(routing_key, true, false, false, null)
+      tempChannel.queueBind(routing_key, exchange, routing_key)
+    }
     tempChannel.basicPublish(exchange, routing_key, null, message.toString.getBytes)
   }
 

--- a/app/services/rabbitmq/RabbitMQMessageService.scala
+++ b/app/services/rabbitmq/RabbitMQMessageService.scala
@@ -230,7 +230,7 @@ class RabbitMQMessageService extends MessageService {
 
   /** Submit a message to broker. */
   override def submit(exchange: String, routing_key: String, message: JsValue, exchange_type: String = "topic") = {
-    // This probably isn't going to extract queue (use other submit() for that) so make a new broker
+    connect()
     val tempChannel = connection.get.createChannel()
     tempChannel.exchangeDeclare(exchange, exchange_type, true)
     

--- a/app/services/rabbitmq/RabbitMQMessageService.scala
+++ b/app/services/rabbitmq/RabbitMQMessageService.scala
@@ -233,8 +233,6 @@ class RabbitMQMessageService extends MessageService {
     // This probably isn't going to extract queue (use other submit() for that) so make a new broker
     val tempChannel = connection.get.createChannel()
     tempChannel.exchangeDeclare(exchange, exchange_type, true)
-    tempChannel.queueDeclare(routing_key, true, false, false, null)
-    tempChannel.queueBind(routing_key, exchange, routing_key)
     tempChannel.basicPublish(exchange, routing_key, null, message.toString.getBytes)
   }
 

--- a/doc/src/sphinx/conf.py
+++ b/doc/src/sphinx/conf.py
@@ -22,7 +22,7 @@ copyright = '2019, University of Illinois at Urbana-Champaign'
 author = 'Luigi Marini'
 
 # The full version, including alpha/beta/rc tags
-release = '1.15.0'
+release = '1.15.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -13,7 +13,7 @@ import NativePackagerKeys._
 object ApplicationBuild extends Build {
 
   val appName = "clowder"
-  val version = "1.15.0"
+  val version = "1.15.1"
   val jvm = "1.7"
 
   def appVersion: String = {

--- a/public/swagger.yml
+++ b/public/swagger.yml
@@ -9,7 +9,7 @@ info:
     Clowder is a customizable and scalable data management system to support any
     data format and multiple research domains. It is under active development
     and deployed for a variety of research projects.
-  version: 1.15.0
+  version: 1.15.1
   termsOfService: https://clowder.ncsa.illinois.edu/clowder/tos
   contact:
     name: Clowder


### PR DESCRIPTION
## 1.15.1 - 2021-03-12

### Fixed
- Several views were throwing errors trying to access a None value in `EventSinkService` when a user was not logged in. 
  Replaced `get()` with `getOrElse()`.
- Consolidated field names sent by the EventSinkService to maximize reuse.
- Changed `EventSinkService` logging to debug to minimize chatter.
- Don't automatically create eventsink queue and bind it to eventsink exchange. Let clients do that so that we don't 
  have a queue for the eventsink filling up if there are no consumers.