### PR TITLE
Add events to track when users archive/unarchive a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unrelease
+
+### Added
+- Log an event each time that a user archives or unarchives a file.
+
 ## 1.16.0 - 2021-03-31
 
 ### Fixed

--- a/app/api/Files.scala
+++ b/app/api/Files.scala
@@ -1856,9 +1856,11 @@ class Files @Inject()(
   }
 
   def archive(id: UUID) = PermissionAction(Permission.ArchiveFile, Some(ResourceRef(ResourceRef.file, id))) { implicit request =>
+    implicit val user = request.user
     files.get(id) match {
       case Some(file) => {
         files.setStatus(id, FileStatus.ARCHIVED)
+        sinkService.logFileArchiveEvent(file, user)
         Ok(toJson(Map("status" -> "success")))
       }
       case None => {
@@ -1869,9 +1871,11 @@ class Files @Inject()(
   }
 
   def unarchive(id: UUID) = PermissionAction(Permission.ArchiveFile, Some(ResourceRef(ResourceRef.file, id))) { implicit request =>
+    implicit val user = request.user
     files.get(id) match {
       case Some(file) => {
         files.setStatus(id, FileStatus.PROCESSED)
+        sinkService.logFileUnarchiveEvent(file, user)
         Ok(toJson(Map("status" -> "success")))
       }
       case None => {

--- a/app/services/EventSinkService.scala
+++ b/app/services/EventSinkService.scala
@@ -261,6 +261,34 @@ class EventSinkService {
       "size" -> (dataset.files.length + dataset.folders.length)
     ))
   }
+
+  def logFileArchiveEvent(file: File, archiver: Option[User]) = {
+    logEvent(Json.obj(
+      "category" -> "archive",
+      "type" -> "file",
+      "resource_id" -> file.id,
+      "resource_name" -> file.filename,
+      "author_id" -> file.author.id,
+      "author_name" -> file.author.fullName,
+      "user_id" -> archiver.get.id,
+      "user_name" -> archiver.get.getMiniUser.fullName,
+      "size" -> file.length
+    ))
+  }
+
+  def logFileUnarchiveEvent(file: File, unarchiver: Option[User]) = {
+    logEvent(Json.obj(
+      "category" -> "unarchive",
+      "type" -> "file",
+      "resource_id" -> file.id,
+      "resource_name" -> file.filename,
+      "author_id" -> file.author.id,
+      "author_name" -> file.author.fullName,
+      "user_id" -> unarchiver.get.id,
+      "user_name" -> unarchiver.get.getMiniUser.fullName,
+      "size" -> file.length
+    ))
+  }
 }
 
 //case class EventSinkMessage(created: Long, category: String, metadata: JsValue)


### PR DESCRIPTION
## Description

### Problem
We don't currently have a way to track if/when a file was archived or unarchived over time.

### Approach
* Add events for tracking archive / unarchive operations on a file

### How to Test
Prerequisites:
* Clowder configured to point at RabbitMQ/Minio
* Clowder configured to use S3 Archiver for archival
* S3 Archiver configured to point at RabbitMQ/Minio/Clowder

Steps:
1. Checkout and run this branch locally
2. Login to Clowder
    * You should see an event has been tracked in the Clowder logs
3. Create and View a Dataset
    * You should see an event has been tracked in the Clowder logs
4. Upload a File
    * You should see an event has been tracked in the Clowder logs
5. Archive the File
    * You should see an event has been tracked in the Clowder logs
6. Unarchive the File
    * You should see an event has been tracked in the Clowder logs

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [x] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the CHANGELOG.md.
- [ ] I have signed the CLA
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
