### PR TITLE
HOTFIX: Close channel after submitting via EventSinkService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## UNRELEASED
 
+### Fixed
+- Close channel after submitting via RabbitMQMessageService
+
 ### Changed
 - Updated Sphinx dependencies due to security and changes in required packages.
 

--- a/app/services/rabbitmq/RabbitMQMessageService.scala
+++ b/app/services/rabbitmq/RabbitMQMessageService.scala
@@ -234,14 +234,18 @@ class RabbitMQMessageService extends MessageService {
     var tempChannel: Channel = null
     try {
       tempChannel = connection.get.createChannel()
-      tempChannel.exchangeDeclare(exchange, exchange_type, true)
+      if (tempChannel != null) {
+        tempChannel.exchangeDeclare(exchange, exchange_type, true)
 
-      // If a routing_key (queue name) was provided, ensure that the queue exists
-      if (routing_key != "") {
-        tempChannel.queueDeclare(routing_key, true, false, false, null)
-        tempChannel.queueBind(routing_key, exchange, routing_key)
+        // If a routing_key (queue name) was provided, ensure that the queue exists
+        if (routing_key != "") {
+          tempChannel.queueDeclare(routing_key, true, false, false, null)
+          tempChannel.queueBind(routing_key, exchange, routing_key)
+        }
+        tempChannel.basicPublish(exchange, routing_key, null, message.toString.getBytes)
+      } else {
+        Logger.error("Error: no channels available to submit message")
       }
-      tempChannel.basicPublish(exchange, routing_key, null, message.toString.getBytes)
     } finally {
       if (tempChannel != null) {
         tempChannel.close()

--- a/app/services/rabbitmq/RabbitMQMessageService.scala
+++ b/app/services/rabbitmq/RabbitMQMessageService.scala
@@ -231,15 +231,22 @@ class RabbitMQMessageService extends MessageService {
   /** Submit a message to broker. */
   override def submit(exchange: String, routing_key: String, message: JsValue, exchange_type: String = "topic") = {
     connect()
-    val tempChannel = connection.get.createChannel()
-    tempChannel.exchangeDeclare(exchange, exchange_type, true)
-    
-    // If a routing_key (queue name) was provided, ensure that the queue exists
-    if (routing_key != "") {
-      tempChannel.queueDeclare(routing_key, true, false, false, null)
-      tempChannel.queueBind(routing_key, exchange, routing_key)
+    var tempChannel: Channel = null
+    try {
+      tempChannel = connection.get.createChannel()
+      tempChannel.exchangeDeclare(exchange, exchange_type, true)
+
+      // If a routing_key (queue name) was provided, ensure that the queue exists
+      if (routing_key != "") {
+        tempChannel.queueDeclare(routing_key, true, false, false, null)
+        tempChannel.queueBind(routing_key, exchange, routing_key)
+      }
+      tempChannel.basicPublish(exchange, routing_key, null, message.toString.getBytes)
+    } finally {
+      if (tempChannel != null) {
+        tempChannel.close()
+      }
     }
-    tempChannel.basicPublish(exchange, routing_key, null, message.toString.getBytes)
   }
 
   /**

--- a/doc/src/sphinx/requirements.txt
+++ b/doc/src/sphinx/requirements.txt
@@ -16,7 +16,6 @@ pytz==2021.1
 recommonmark==0.6.0
 requests==2.25.1
 snowballstemmer==2.1.0
-sphinx-rtd-theme==0.5.0
 sphinx==3.1.2
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2


### PR DESCRIPTION
## Description

### Problem
We are not closing channels in `RabbitMQMessageService.submit()`.

This leads to the following issue in production:
```
Failed to submit event sink message
java.lang.NullPointerException: null
```

`createChannel()` will return `null` if no channels are available, and since we are not closing these channels properly, no more are available.

### Approach
* Add a `null` check after `createChannel`
* Close the `tempChannel` after sending the message 


## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [x] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the CHANGELOG.md.
- [ ] I have signed the CLA
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
