### PR TITLE
Persistent status queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   folders and technical metadata. Downloading datasets now includes extra Datacite and Clowder metadata.
 - Endpoint /api/files/bulkRemove to delete multiple files in one call. [#12](https://github.com/clowder-framework/clowder/issues/12)
 - Log an event each time that a user archives or unarchives a file.
+- Clowder will use the same queue for responses, preventing status messages from getting lost.
 
 ### Changed
 - Updated Sphinx dependencies due to security and changes in required packages.

--- a/app/Global.scala
+++ b/app/Global.scala
@@ -45,6 +45,9 @@ object Global extends WithFilters(new GzipFilter(), new Jsonp(), CORSFilter()) w
 
     val users: UserService = DI.injector.getInstance(classOf[UserService])
 
+    // get clowder unique ID
+    Logger.info(s"Starting clowder with id = ${AppConfiguration.getInstance}")
+
     // set the default ToS version
     AppConfiguration.setDefaultTermsOfServicesVersion()
 

--- a/app/api/Status.scala
+++ b/app/api/Status.scala
@@ -31,7 +31,8 @@ class Status @Inject()(spaces: SpaceService,
 
   def status = UserAction(needActive=false) { implicit request =>
 
-    Ok(Json.obj("version" -> getVersionInfo,
+    Ok(Json.obj("instance" -> AppConfiguration.getInstance,
+      "version" -> getVersionInfo,
       "counts" -> getCounts(request.user),
       "plugins" -> getPlugins(request.user),
       "extractors" -> Json.toJson(extractors.getExtractorNames(List.empty))))

--- a/app/services/AppConfigurationService.scala
+++ b/app/services/AppConfigurationService.scala
@@ -71,6 +71,18 @@ object AppConfiguration {
   val appConfig: AppConfigurationService = DI.injector.getInstance(classOf[AppConfigurationService])
 
   // ----------------------------------------------------------------------
+  def getInstance: String = {
+    appConfig.getProperty[String]("instance") match {
+      case Some(id) => id
+      case None => {
+        val id = scala.util.Random.alphanumeric.take(10).mkString
+        appConfig.setProperty("instance", id)
+        id
+      }
+    }
+  }
+
+  // ----------------------------------------------------------------------
 
   /** Set the default theme */
   def setTheme(theme: String) = {

--- a/app/services/rabbitmq/RabbitMQMessageService.scala
+++ b/app/services/rabbitmq/RabbitMQMessageService.scala
@@ -100,8 +100,9 @@ class RabbitMQMessageService extends MessageService {
       }
 
       // create an anonymous queue for replies
-      val replyQueueName = channel.get.queueDeclare().getQueue
-      Logger.debug("Reply queue name: " + replyQueueName)
+      val replyQueueName = s"clowder.${AppConfiguration.getInstance}"
+      channel.get.queueDeclare(replyQueueName, true, false, false, null)
+      Logger.info("Reply queue name: " + replyQueueName)
 
       // get bindings stored in broker
       val queueBindingsFuture = getQueuesNamesForAnExchange(exchange)


### PR DESCRIPTION
## Description

When (re)starting clowder it will create an anonymous queue for responses. This will make sure clowder has a persistent ID that is used for the response queue for extractors. This will make it such that if clowder restarts it will get all the status messages from extractors.

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [x] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the CHANGELOG.md.
- [ ] I have signed the CLA
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
