### PR TITLE
use clowder.url for absolute url (fixes #224)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Added
+- Can set the clowder url in configuration file [#224](https://github.com/clowder-framework/clowder/issues/224)
+
 ## 1.17.0 - 2021-04-29
 
 ### Fixed

--- a/app/api/Collections.scala
+++ b/app/api/Collections.scala
@@ -120,7 +120,7 @@ class Collections @Inject() (datasets: DatasetService,
           else BadRequest(toJson(Map("status" -> "reindex queuing failed, Elasticsearch may be disabled")))
         }
         case None => {
-          Logger.error("Error getting collection" + id)
+          Logger.error("Error getting collection " + id)
           BadRequest(toJson(s"The given collection id $id is not a valid ObjectId."))
         }
       }

--- a/app/api/CurationObjects.scala
+++ b/app/api/CurationObjects.scala
@@ -55,15 +55,15 @@ class CurationObjects @Inject()(datasets: DatasetService,
               "Creation Date" -> Json.toJson(format.format(file.uploadDate)),
               "Label" -> Json.toJson(file.filename),
               "Title" -> Json.toJson(file.filename),
-              "Uploaded By" -> Json.toJson(userService.findById(file.author.id).map ( usr => Json.toJson(file.author.fullName + ": " +  api.routes.Users.findById(usr.id).absoluteURL(https)))),
+              "Uploaded By" -> Json.toJson(userService.findById(file.author.id).map ( usr => Json.toJson(file.author.fullName + ": " +  controllers.Utils.baseUrl(request) + api.routes.Users.findById(usr.id)))),
               "Size" -> Json.toJson(size),
               "Mimetype" -> Json.toJson(file.contentType),
               "Publication Date" -> Json.toJson(""),
               "External Identifier" -> Json.toJson(""),
               "SHA512 Hash" -> Json.toJson(file.sha512),
               "@type" -> Json.toJson(Seq("AggregatedResource", "http://cet.ncsa.uiuc.edu/2015/File")),
-              "Is Version Of" -> Json.toJson(controllers.routes.Files.file(file.fileId).absoluteURL(https) + "?key=" + key),
-              "similarTo" -> Json.toJson(api.routes.Files.download(file.fileId).absoluteURL(https)  + "?key=" + key)
+              "Is Version Of" -> Json.toJson(controllers.Utils.baseUrl(request) + controllers.routes.Files.file(file.fileId) + "?key=" + key),
+              "similarTo" -> Json.toJson(controllers.Utils.baseUrl(request) + api.routes.Files.download(file.fileId)  + "?key=" + key)
 
             )
             if(file.tags.size > 0 ) {
@@ -83,10 +83,10 @@ class CurationObjects @Inject()(datasets: DatasetService,
                 "License" -> Json.toJson(c.datasets(0).licenseData.m_licenseText),
                 "Label" -> Json.toJson(folder.name),
                 "Title" -> Json.toJson(folder.displayName),
-                "Uploaded By" -> Json.toJson(folder.author.fullName + ": " +  api.routes.Users.findById(folder.author.id).absoluteURL(https)),
+                "Uploaded By" -> Json.toJson(folder.author.fullName + ": " +  controllers.Utils.baseUrl(request) + api.routes.Users.findById(folder.author.id)),
                 "@id" -> Json.toJson("urn:uuid:"+folder.id),
                 "@type" -> Json.toJson(Seq("AggregatedResource", "http://cet.ncsa.uiuc.edu/2016/Folder")),
-                "Is Version Of" -> Json.toJson(controllers.routes.Datasets.dataset(c.datasets(0).id).absoluteURL(https) +"#folderId=" +folder.folderId),
+                "Is Version Of" -> Json.toJson(controllers.Utils.baseUrl(request) + controllers.routes.Datasets.dataset(c.datasets(0).id) +"#folderId=" +folder.folderId),
                 "Has Part" -> Json.toJson(hasPart)
               )
               tempMap
@@ -107,7 +107,7 @@ class CurationObjects @Inject()(datasets: DatasetService,
               "comment_body" -> Json.toJson(comm.text),
               "comment_date" -> Json.toJson(format.format(comm.posted)),
               "Identifier" -> Json.toJson("urn:uuid:"+comm.id),
-              "comment_author" -> Json.toJson(userService.findById(comm.author.id).map ( usr => Json.toJson(usr.fullName + ": " +  api.routes.Users.findById(usr.id).absoluteURL(https))))
+              "comment_author" -> Json.toJson(userService.findById(comm.author.id).map ( usr => Json.toJson(usr.fullName + ": " +  controllers.Utils.baseUrl(request) + api.routes.Users.findById(usr.id))))
             ))
           }
           var metadataList = scala.collection.mutable.ListBuffer.empty[MetadataPair]
@@ -220,23 +220,23 @@ class CurationObjects @Inject()(datasets: DatasetService,
                   "Label" -> Json.toJson(c.name),
                   "Title" -> Json.toJson(c.name),
                   "Dataset Description" -> Json.toJson(c.description),
-                  "Uploaded By" -> Json.toJson(userService.findById(c.author.id).map ( usr => Json.toJson(usr.fullName + ": " + api.routes.Users.findById(usr.id).absoluteURL(https)))),
+                  "Uploaded By" -> Json.toJson(userService.findById(c.author.id).map ( usr => Json.toJson(usr.fullName + ": " + controllers.Utils.baseUrl(request) + api.routes.Users.findById(usr.id)))),
                   "Publication Date" -> Json.toJson(publicationDate),
                   "Published In" -> Json.toJson(""),
                   "External Identifier" -> Json.toJson(""),
                   "Proposed for publication" -> Json.toJson("true"),
-                  "@id" -> Json.toJson(api.routes.CurationObjects.getCurationObjectOre(c.id).absoluteURL(https) + "#aggregation"),
+                  "@id" -> Json.toJson(controllers.Utils.baseUrl(request) + api.routes.CurationObjects.getCurationObjectOre(c.id) + "#aggregation"),
                   "@type" -> Json.toJson(Seq("Aggregation", "http://cet.ncsa.uiuc.edu/2015/Dataset")),
-                  "Is Version Of" -> Json.toJson(controllers.routes.Datasets.dataset(c.datasets(0).id).absoluteURL(https)),
-                  "similarTo" -> Json.toJson(controllers.routes.Datasets.dataset(c.datasets(0).id).absoluteURL(https)),
+                  "Is Version Of" -> Json.toJson(controllers.Utils.baseUrl(request) + controllers.routes.Datasets.dataset(c.datasets(0).id)),
+                  "similarTo" -> Json.toJson(controllers.Utils.baseUrl(request) + controllers.routes.Datasets.dataset(c.datasets(0).id)),
                   "aggregates" -> Json.toJson(filesJson ++ foldersJson.toList),
                   "Has Part" -> Json.toJson(hasPart),
-                  "Publishing Project"-> Json.toJson(controllers.routes.Spaces.getSpace(c.space).absoluteURL(https))
+                  "Publishing Project"-> Json.toJson(controllers.Utils.baseUrl(request) + controllers.routes.Spaces.getSpace(c.space))
                 )),
               "Creation Date" -> Json.toJson(format.format(c.created)),
-              "Uploaded By" -> Json.toJson(userService.findById(c.author.id).map ( usr => Json.toJson(usr.fullName + ": " +  api.routes.Users.findById(usr.id).absoluteURL(https)))),
+              "Uploaded By" -> Json.toJson(userService.findById(c.author.id).map ( usr => Json.toJson(usr.fullName + ": " +  controllers.Utils.baseUrl(request) + api.routes.Users.findById(usr.id)))),
               "@type" -> Json.toJson("ResourceMap"),
-              "@id" -> Json.toJson(api.routes.CurationObjects.getCurationObjectOre(curationId).absoluteURL(https))
+              "@id" -> Json.toJson(controllers.Utils.baseUrl(request) + api.routes.CurationObjects.getCurationObjectOre(curationId))
             )
 
           Ok(Json.toJson(parsedValue))

--- a/app/api/Datasets.scala
+++ b/app/api/Datasets.scala
@@ -604,7 +604,7 @@ class  Datasets @Inject()(
                   }
                 }
                 case None => {
-                  Logger.error("Error getting dataset" + id)
+                  Logger.error("Error getting dataset " + id)
                   BadRequest(toJson(s"The given dataset id $id is not a valid ObjectId."))
                 }
               }
@@ -644,7 +644,7 @@ class  Datasets @Inject()(
               }
             }
             case None => {
-              Logger.error("Error getting dataset" + dsId)
+              Logger.error("Error getting dataset " + dsId)
               BadRequest(toJson(s"The given dataset id $dsId is not a valid ObjectId."))
             }
           }
@@ -666,7 +666,7 @@ class  Datasets @Inject()(
         else BadRequest(toJson(Map("status" -> "reindex queuing failed, Elasticsearch may be disabled")))
       }
       case None => {
-        Logger.error("Error getting dataset" + id)
+        Logger.error("Error getting dataset " + id)
         BadRequest(toJson(s"The given dataset id $id is not a valid ObjectId."))
       }
     }
@@ -722,13 +722,13 @@ class  Datasets @Inject()(
             Ok(toJson(Map("status" -> "success")))
           }
           case None => {
-            Logger.error("Error getting file" + fileId)
+            Logger.error("Error getting file " + fileId)
             BadRequest(toJson(s"The given dataset id $dsId is not a valid ObjectId."))
           }
         }
       }
       case None => {
-        Logger.error("Error getting dataset" + dsId)
+        Logger.error("Error getting dataset " + dsId)
         BadRequest(toJson(s"The given dataset id $dsId is not a valid ObjectId."))
       }
     }
@@ -815,19 +815,19 @@ class  Datasets @Inject()(
                 Ok (toJson (Map ("status" -> "success") ) )
               }
               case None => {
-                Logger.error ("Error getting file" + fileId)
+                Logger.error ("Error getting file " + fileId)
                 BadRequest (toJson (s"The given file id $fileId is not a valid ObjectId.") )
               }
             }
           }
           case None => {
-            Logger.error ("Error getting dataset" + toDatasetId)
+            Logger.error ("Error getting dataset " + toDatasetId)
             BadRequest (toJson (s"The given dataset id $toDatasetId is not a valid ObjectId.") )
           }
         }
       }
       case None => {
-        Logger.error ("Error getting dataset" + datasetId)
+        Logger.error ("Error getting dataset " + datasetId)
         BadRequest (toJson (s"The given dataset id $datasetId is not a valid ObjectId.") )
       }
     }
@@ -1058,7 +1058,7 @@ class  Datasets @Inject()(
           Ok(toJson(list))
         }
       }
-      case None => Logger.error("Error getting dataset" + id); InternalServerError
+      case None => Logger.error("Error getting dataset " + id); InternalServerError
     }
   }
 
@@ -1095,7 +1095,7 @@ class  Datasets @Inject()(
         }
         Ok(toJson(list))
       }
-      case None => Logger.error("Error getting dataset" + id); InternalServerError
+      case None => Logger.error("Error getting dataset " + id); InternalServerError
     }
   }
 
@@ -1945,7 +1945,7 @@ class  Datasets @Inject()(
         Ok(jsonPreviewsFiles(previewslist.asInstanceOf[List[(models.File, List[(java.lang.String, String, String, String, java.lang.String, String, Long)])]]))
       }
       case None => {
-        Logger.error("Error getting dataset" + id); InternalServerError
+        Logger.error("Error getting dataset " + id); InternalServerError
       }
     }
   }
@@ -2792,7 +2792,7 @@ class  Datasets @Inject()(
     datasets.get(id) match {
       case Some(dataset) => {
         val bagit = play.api.Play.configuration.getBoolean("downloadDatasetBagit").getOrElse(true)
-        val baseURL = controllers.routes.Datasets.dataset(id).absoluteURL(https(request))
+        val baseURL = controllers.Utils.baseUrl(request) + controllers.routes.Datasets.dataset(id)
 
         // Increment download count if tracking is enabled
         if (tracking) {
@@ -2821,7 +2821,7 @@ class  Datasets @Inject()(
       case Some(dataset) => {
         val fileIDs = fileList.split(',').map(fid => new UUID(fid)).toList
         val bagit = play.api.Play.configuration.getBoolean("downloadDatasetBagit").getOrElse(true)
-        val baseURL = controllers.routes.Datasets.dataset(id).absoluteURL(https(request))
+        val baseURL = controllers.Utils.baseUrl(request) + controllers.routes.Datasets.dataset(id)
 
         // Increment download count for each file
         fileIDs.foreach(fid => files.incrementDownloads(fid, user))
@@ -2846,7 +2846,7 @@ class  Datasets @Inject()(
     datasets.get(id) match {
       case Some(dataset) => {
         val bagit = play.api.Play.configuration.getBoolean("downloadDatasetBagit").getOrElse(true)
-        val baseURL = controllers.routes.Datasets.dataset(id).absoluteURL(https(request))
+        val baseURL = controllers.Utils.baseUrl(request) + controllers.routes.Datasets.dataset(id)
 
 
         // Increment download count for each file in folder

--- a/app/api/Metadata.scala
+++ b/app/api/Metadata.scala
@@ -449,7 +449,7 @@ class Metadata @Inject() (
 
           // build creator uri
           // TODO switch to internal id and then build url when returning?
-          val userURI = controllers.routes.Application.index().absoluteURL() + "api/users/" + user.id
+          val userURI = controllers.Utils.baseUrl(request) + "/api/users/" + user.id
           val creator = UserAgent(user.id, "cat:user", MiniUser(user.id, user.fullName, user.avatarUrl.getOrElse(""), user.email), Some(new URL(userURI)))
 
           val context: JsValue = (json \ "@context")

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -30,7 +30,7 @@ class Application @Inject() (files: FileService, collections: CollectionService,
   }
 
   def swaggerUI = Action { implicit request =>
-    val swagger = routes.Application.swagger().absoluteURL(Utils.https(request))
+    val swagger = controllers.Utils.baseUrl(request) + routes.Application.swagger()
     Redirect("http://clowder.ncsa.illinois.edu/swagger/?url=" + swagger)
   }
 
@@ -40,7 +40,6 @@ class Application @Inject() (files: FileService, collections: CollectionService,
   def swagger = Action  { implicit request =>
     Play.resource("/public/swagger.yml") match {
       case Some(resource) => {
-        val https = Utils.https(request)
         val clowderurl = new URL(Utils.baseUrl(request))
         val host = if (clowderurl.getPort == -1) {
           clowderurl.getHost
@@ -64,10 +63,10 @@ class Application @Inject() (files: FileService, collections: CollectionService,
                 "  title: " + AppConfiguration.getDisplayName + "\n" +
                 "  description: " + AppConfiguration.getWelcomeMessage + "\n" +
                 "  version: \"" + sys.props.getOrElse("build.version", default = "0.0.0").toString + "\"\n" +
-                "  termsOfService: " + routes.Application.tos().absoluteURL(https) + "\n" +
+                "  termsOfService: " + controllers.Utils.baseUrl(request) + routes.Application.tos() + "\n" +
                 "  contact: " + "\n" +
                 "    name: " + AppConfiguration.getDisplayName + "\n" +
-                "    url: " + routes.Application.email().absoluteURL(https) + "\n"
+                "    url: " + controllers.Utils.baseUrl(request) + routes.Application.email() + "\n"
             } else if (line.startsWith("servers:")) {
               skipit = true
               "servers:\n" +

--- a/app/controllers/Datasets.scala
+++ b/app/controllers/Datasets.scala
@@ -739,8 +739,8 @@ class Datasets @Inject() (
             Map("files" -> uploadedFiles.map(f => toJson(Map(
               "name" -> toJson(f.filename),
               "size" -> toJson(f.length),
-              "url" -> toJson(routes.Files.file(f.id).absoluteURL(Utils.https(request))),
-              "deleteUrl" -> toJson(api.routes.Files.removeFile(f.id).absoluteURL(Utils.https(request))),
+              "url" -> toJson(controllers.Utils.baseUrl(request) + routes.Files.file(f.id)),
+              "deleteUrl" -> toJson(controllers.Utils.baseUrl(request) + api.routes.Files.removeFile(f.id)),
               "deleteType" -> toJson("POST")
             ))))
           }

--- a/app/controllers/Error.scala
+++ b/app/controllers/Error.scala
@@ -20,7 +20,7 @@ class Error extends SecuredController {
      * 
      */
     def authenticationRequired() = UserAction(needActive = false) { implicit request =>
-        Results.Redirect(RoutesHelper.login.absoluteURL(IdentityProvider.sslEnabled)).flashing("error" -> "You must be logged in to perform that action.")
+        Results.Redirect(controllers.Utils.baseUrl(request) + RoutesHelper.login).flashing("error" -> "You must be logged in to perform that action.")
     }
     
     /**
@@ -49,10 +49,10 @@ class Error extends SecuredController {
         }
         
         if (origUrlPresent) {
-            Results.Redirect(RoutesHelper.login.absoluteURL(IdentityProvider.sslEnabled)).flashing("error" -> errMsg).withSession("original-url" -> url)
+            Results.Redirect(controllers.Utils.baseUrl(request) + RoutesHelper.login).flashing("error" -> errMsg).withSession("original-url" -> url)
         }
         else {
-            Results.Redirect(RoutesHelper.login.absoluteURL(IdentityProvider.sslEnabled)).flashing("error" -> errMsg)
+            Results.Redirect(controllers.Utils.baseUrl(request) + RoutesHelper.login).flashing("error" -> errMsg)
         }
     }
     

--- a/app/controllers/Files.scala
+++ b/app/controllers/Files.scala
@@ -646,8 +646,8 @@ class Files @Inject() (
                     Map(
                       "name" -> toJson(nameOfFile),
                       "size" -> toJson(uploadedFile.ref.file.length()),
-                      "url" -> toJson(routes.Files.file(f.id).absoluteURL(https)),
-                      "deleteUrl" -> toJson(api.routes.Files.removeFile(f.id).absoluteURL(https)),
+                      "url" -> toJson(controllers.Utils.baseUrl(request) + routes.Files.file(f.id)),
+                      "deleteUrl" -> toJson(controllers.Utils.baseUrl(request) + api.routes.Files.removeFile(f.id)),
 	                            "deleteType" -> toJson("POST")
 	                        )
 	                    )

--- a/app/controllers/RSS.scala
+++ b/app/controllers/RSS.scala
@@ -65,13 +65,13 @@ class RSS @Inject() (events: EventService) extends SecuredController {
         <channel>
           <title>{AppConfiguration.getDisplayName} RSS feed</title>
           <description>The latest events happening in {AppConfiguration.getDisplayName}</description>
-          <link>{routes.Application.index().absoluteURL()}</link>
+          <link>{controllers.Utils.baseUrl(request) + routes.Application.index()}</link>
           {
             for (item <- feedItems) yield {
               <item>
                 <title>Event</title>
                 <description>{item.user.fullName}{views.html.newsFeedCardEmail(item)}</description>
-                <link>{getItemLink(item).absoluteURL()}</link>
+                <link>{controllers.Utils.baseUrl(request) + getItemLink(item)}</link>
               </item>
             }
           }
@@ -97,13 +97,13 @@ class RSS @Inject() (events: EventService) extends SecuredController {
         <channel>
           <title>{AppConfiguration.getDisplayName} RSS feed</title>
           <description>The latest events happening in {AppConfiguration.getDisplayName}</description>
-          <link>{routes.Application.index().absoluteURL()}</link>
+          <link>{controllers.Utils.baseUrl(request) + routes.Application.index()}</link>
           {
           for (item <- feedItems) yield {
             <item>
               <title>Event</title>
               <description>{item.user.fullName}{views.html.newsFeedCardEmail(item)}</description>
-              <link>{getItemLink(item).absoluteURL()}</link>
+              <link>{controllers.Utils.baseUrl(request) + getItemLink(item)}</link>
             </item>
           }
           }

--- a/app/controllers/Registration.scala
+++ b/app/controllers/Registration.scala
@@ -32,9 +32,9 @@ class Registration @Inject()(spaces: SpaceService, users: UserService) extends S
 
   def signUp(token: String) = Action { implicit request =>
     if ( play.Play.application().configuration().getBoolean("enableUsernamePassword") ) {
-      Redirect(securesocial.core.providers.utils.RoutesHelper.signUp(token).absoluteURL(IdentityProvider.sslEnabled))
+      Redirect(controllers.Utils.baseUrl(request) + securesocial.core.providers.utils.RoutesHelper.signUp(token))
     } else {
-      Redirect(securesocial.core.providers.utils.RoutesHelper.login.absoluteURL(IdentityProvider.sslEnabled))
+      Redirect(controllers.Utils.baseUrl(request) + securesocial.core.providers.utils.RoutesHelper.login)
     }
   }
 

--- a/app/controllers/Utils.scala
+++ b/app/controllers/Utils.scala
@@ -3,9 +3,10 @@ package controllers
 import java.net.URL
 import models._
 import play.api.data.format.Formatter
-import play.api.data.{Mapping, Forms, FormError}
-import play.api.mvc.{RequestHeader, Request}
+import play.api.data.{FormError, Forms, Mapping}
+import play.api.mvc.{Request, RequestHeader}
 import org.apache.commons.lang.StringEscapeUtils
+import play.Play
 
 import scala.collection.mutable.ListBuffer
 
@@ -14,9 +15,12 @@ object Utils {
    * Return base url given a request. This will add http or https to the front, for example
    * https://localhost:9443 will be returned if it is using https.
    */
-  def baseUrl(request: Request[Any], absolute: Boolean = true) = {
+  def baseUrl(request: RequestHeader, absolute: Boolean = true) = {
     if (absolute) {
-      routes.Files.list().absoluteURL(https(request))(request).replace("/files", "")
+      Play.application.configuration.getString("clowder.url") match {
+        case s:String => s
+        case _ => routes.Files.list().absoluteURL(https(request))(request).replace("/files", "")
+      }
     } else {
       routes.Files.list().url.replace("/files", "")
     }

--- a/app/services/CrowdProvider.scala
+++ b/app/services/CrowdProvider.scala
@@ -31,7 +31,7 @@ class CrowdProvider(application: Application) extends IdentityProvider(applicati
       val token = UUID.generate().stringify
       val userip = request.remoteAddress
       UserService.save(new Token(token, userip, DateTime.now(), DateTime.now().plusMinutes(CrowdProvider.crowdServerTimeOut), false))
-      val query = Map[String, Seq[String]]("redirecturl" -> Seq[String](RoutesHelper.authenticate(id).absoluteURL()),
+      val query = Map[String, Seq[String]]("redirecturl" -> Seq[String](controllers.Utils.baseUrl(request) + RoutesHelper.authenticate(id)),
         "token" -> Seq[String](token))
       Left(Results.Redirect(CrowdProvider.crowdServerURL, query))
     } else {

--- a/app/services/LdapProvider.scala
+++ b/app/services/LdapProvider.scala
@@ -30,7 +30,7 @@ class LdapProvider(application: Application) extends IdentityProvider(applicatio
       val token = UUID.generate().stringify
       val userip = request.remoteAddress
       UserService.save(new Token(token, userip, DateTime.now(), DateTime.now().plusMinutes(LdapProvider.ldapServerTimeOut), false))
-      val query = Map[String, Seq[String]]("redirecturl" -> Seq[String](RoutesHelper.authenticate(id).absoluteURL()),
+      val query = Map[String, Seq[String]]("redirecturl" -> Seq[String](controllers.Utils.baseUrl(request) + RoutesHelper.authenticate(id)),
         "token" -> Seq[String](token))
       Left(Results.Redirect(LdapProvider.ldapServerURL, query))
     } else {

--- a/app/services/VersusPlugin.scala
+++ b/app/services/VersusPlugin.scala
@@ -36,7 +36,7 @@ class VersusPlugin(application: Application) extends Plugin {
     val configuration = play.api.Play.configuration
     val key = "?key=" + configuration.getString("commKey").get
     val https = controllers.Utils.https(request)
-    val fileUrl = api.routes.Files.download(fileid).absoluteURL(https) + key
+    val fileUrl = controllers.Utils.baseUrl(request) + api.routes.Files.download(fileid) + key
     val host = configuration.getString("versus.host").getOrElse("")
 
     val extractUrl = host + "/extract"
@@ -319,7 +319,7 @@ class VersusPlugin(application: Application) extends Plugin {
     val configuration = play.api.Play.configuration
     val key = "?key=" + configuration.getString("commKey").get
     val https = controllers.Utils.https(request)
-    val prevURL = api.routes.Previews.download(previewId).absoluteURL(https) + key
+    val prevURL = controllers.Utils.baseUrl(request) + api.routes.Previews.download(previewId) + key
     val host = configuration.getString("versus.host").getOrElse("")
 
     //find out what extractor created this preview
@@ -350,7 +350,7 @@ class VersusPlugin(application: Application) extends Plugin {
     //need 'blob' in fileURL
     val key = "?key=" + configuration.getString("commKey").get
     val https = controllers.Utils.https(request)
-    val fileURL = api.routes.Files.download(fileId).absoluteURL(https) + key
+    val fileURL = controllers.Utils.baseUrl(request) + api.routes.Files.download(fileId) + key
     //indexes that have TYPE parameter contain sections, and indexes that don't have TYPE parameter contain whole files.
     //go through all indexes and find ones that DONT'T have the TYPE param and send file for indexing in these indexes.
     for (indexList <- getIndexesAsFutureList()) {
@@ -470,7 +470,7 @@ class VersusPlugin(application: Application) extends Plugin {
     val configuration = play.api.Play.configuration
     val key = "?key=" + configuration.getString("commKey").get
     val https = controllers.Utils.https(request)
-    val queryStr = api.routes.Files.download(inputFileId).absoluteURL(https) + key
+    val queryStr = controllers.Utils.baseUrl(request) + api.routes.Files.download(inputFileId) + key
 
     queryIndex(queryStr, indexId)
   }
@@ -483,7 +483,7 @@ class VersusPlugin(application: Application) extends Plugin {
     val configuration = play.api.Play.configuration
     val key = "?key=" + configuration.getString("commKey").get
     val https = controllers.Utils.https(request)
-    val queryStr = api.routes.Files.downloadquery(newFileId).absoluteURL(https) + key
+    val queryStr = controllers.Utils.baseUrl(request) + api.routes.Files.downloadquery(newFileId) + key
     queryIndex(queryStr, indexId)
   }
 
@@ -606,7 +606,7 @@ class VersusPlugin(application: Application) extends Plugin {
     //if searching for a new file, i.e.  uploaded just now, use api/queries
     val key = "?key=" + configuration.getString("commKey").get
     val https = controllers.Utils.https(request)
-    val queryStr = api.routes.Files.downloadquery(UUID(inputFileId)).absoluteURL(https) + key
+    val queryStr = controllers.Utils.baseUrl(request) + api.routes.Files.downloadquery(UUID(inputFileId)) + key
     val responseFuture: Future[Response] = WS.url(host + "/indexes/" + indexId + "/query").post(Map("infile" -> Seq(queryStr)))
 
     //example: queryIndexUrl = http://localhost:8080/api/v1/indexes/a885bad2-f463-496f-a881-c01ebd4c31f1/query

--- a/app/services/mongodb/MongoDBCollectionService.scala
+++ b/app/services/mongodb/MongoDBCollectionService.scala
@@ -614,7 +614,7 @@ class MongoDBCollectionService @Inject() (
         }
       }
       case None => {
-        Logger.error("Error getting collection" + collectionId);
+        Logger.error("Error getting collection " + collectionId);
         Failure
       }
     }

--- a/app/services/mongodb/MongoDBFileService.scala
+++ b/app/services/mongodb/MongoDBFileService.scala
@@ -451,7 +451,7 @@ class MongoDBFileService @Inject() (
             if (isInRootNodes) {
               val theResource = rdfDescriptions(i).substring(rdfDescriptions(i).indexOf("\"") + 1, rdfDescriptions(i).indexOf("\"", rdfDescriptions(i).indexOf("\"") + 1))
               // TODO RK : need to make sure we know if it is https
-              var connection = "<rdf:Description rdf:about=\"" + api.routes.Files.get(id).absoluteURL(false)
+              var connection = "<rdf:Description rdf:about=\"" + controllers.Utils.baseUrl(request, false) + api.routes.Files.get(id)
               connection = connection + "\"><P129_is_about xmlns=\"http://www.cidoc-crm.org/rdfs/cidoc_crm_v5.0.2.rdfs#\" rdf:resource=\"" + theResource
               connection = connection + "\"/></rdf:Description>"
               fileWriter.write(connection)

--- a/app/util/FileUtils.scala
+++ b/app/util/FileUtils.scala
@@ -99,7 +99,7 @@ object FileUtils {
     }
 
     val user = request.user.get
-    val creator_url = api.routes.Users.findById(user.id).absoluteURL(Utils.https(request))(request)
+    val creator_url = controllers.Utils.baseUrl(request) + api.routes.Users.findById(user.id)
     val creator = UserAgent(id = UUID.generate(), user = user, userId = Some(new URL(creator_url)))
 
     // Extract path information from requests for later
@@ -300,7 +300,7 @@ object FileUtils {
     }
 
     val user = request.user.get
-    val creator_url = api.routes.Users.findById(user.id).absoluteURL(Utils.https(request))(request)
+    val creator_url = controllers.Utils.baseUrl(request) + api.routes.Users.findById(user.id)
     val creator = UserAgent(id = UUID.generate(), user=user.getMiniUser, userId = Some(new URL(creator_url)))
 
     // Extract path information from requests for later

--- a/app/views/commentform.scala.html
+++ b/app/views/commentform.scala.html
@@ -38,7 +38,7 @@
  function updateComment(id) {
    var text = $("#editField_" + id).val();
    text = htmlEncode(text);
-   editComment(id, text, "@user.get.fullName", "@user.get.email.getOrElse("")", "@routes.Datasets.dataset(UUID(id)).absoluteURL()");
+   editComment(id, text, "@user.get.fullName", "@user.get.email.getOrElse("")", "@controllers.Utils.baseUrl(request)@routes.Datasets.dataset(UUID(id))");
    return false;
  }
 
@@ -126,11 +126,11 @@ function postComment(id, resourceType) {
                 }
                 @resourceType match {
                     case "dataset" => {
-                        emailtext += '@user.get.fullName mentioned you in a comment: @routes.Datasets.dataset(UUID(id)).absoluteURL()\n\n';
+                        emailtext += '@user.get.fullName mentioned you in a comment: @controllers.Utils.baseUrl(request)@routes.Datasets.dataset(UUID(id))\n\n';
                         jsRoutes.api.Comments.mentionInComment(mentioned.id, id, "@resourceName", "dataset", commenterId).ajax({type: 'POST'});
                     }
                     case "file" => {
-                        emailtext += '@user.get.fullName mentioned you in a comment: @routes.Files.file(UUID(id)).absoluteURL()\n\n';
+                        emailtext += '@user.get.fullName mentioned you in a comment: @controllers.Utils.baseUrl(request)@routes.Files.file(UUID(id))\n\n';
                         jsRoutes.api.Comments.mentionInComment(mentioned.id, id, "@resourceName", "file", commenterId).ajax({type: 'POST'});
                     }
                     case _ => {

--- a/app/views/emails/footer.scala.html
+++ b/app/views/emails/footer.scala.html
@@ -6,9 +6,9 @@
 <p>
     <small>
         @if(sender!="") {This message was sent on behalf of <a href="mailto:@sender">@sender</a>.<br/>}
-        This message was sent by <a style="text-decoration:none;" href="@routes.Application.index().absoluteURL(controllers.Utils.https(request))" style="text-decoration: none">@AppConfiguration.getDisplayName</a> an
+        This message was sent by <a style="text-decoration:none;" href="@controllers.Utils.baseUrl(request)@routes.Application.index()" style="text-decoration: none">@AppConfiguration.getDisplayName</a> an
         instance of <a style="text-decoration:none;" href="http://clowder.ncsa.illinois.edu/">Clowder</a> running
         @sys.props.getOrElse("build.version", default = "0.0.0")#@sys.props.getOrElse("build.bamboo", default = "development")<br/>
-        If you have any questions about this email please contact <a style="text-decoration:none;" href="@routes.Application.email().absoluteURL(controllers.Utils.https(request))">the server admins.</a>
+        If you have any questions about this email please contact <a style="text-decoration:none;" href="@controllers.Utils.baseUrl(request)@routes.Application.email()">the server admins.</a>
     </small>
 </p>

--- a/app/views/emails/userActivated.scala.html
+++ b/app/views/emails/userActivated.scala.html
@@ -7,7 +7,7 @@
         @user.fullName,<br/>
         <br>
         <p>
-            Your account on <a href="@routes.Application.index().absoluteURL(ssl)" style="text-decoration: none">@AppConfiguration.getDisplayName</a><br/>
+            Your account on <a href="@controllers.Utils.baseUrl(request)@routes.Application.index()" style="text-decoration: none">@AppConfiguration.getDisplayName</a><br/>
             has been
             @if(active) {
                 enabled and you can now login.

--- a/app/views/emails/userAdmin.scala.html
+++ b/app/views/emails/userAdmin.scala.html
@@ -6,7 +6,7 @@
     <body>
         <p>@user.fullName,</p>
         <p>
-            Your account on <a href="@routes.Application.index().absoluteURL(ssl)" style="text-decoration: none">@AppConfiguration.getDisplayName</a>
+            Your account on <a href="@controllers.Utils.baseUrl(request)@routes.Application.index()" style="text-decoration: none">@AppConfiguration.getDisplayName</a>
             now @if(!admin) { no longer } has admin privileges.
         </p>
         @footer()

--- a/app/views/emails/userSignup.scala.html
+++ b/app/views/emails/userSignup.scala.html
@@ -10,8 +10,8 @@
                     <img src="@user.getAvatarUrl()" border="0" height="48" width="48">
                 </td>
                 <td>
-                    A new user joined <a href="@routes.Application.index().absoluteURL(ssl)" style="text-decoration: none">@AppConfiguration.getDisplayName</a><br/>
-                    <a href="@routes.Profile.viewProfileUUID(user.id).absoluteURL(ssl)" style="text-decoration: none">
+                    A new user joined <a href="@controllers.Utils.baseUrl(request)@routes.Application.index()" style="text-decoration: none">@AppConfiguration.getDisplayName</a><br/>
+                    <a href="@controllers.Utils.baseUrl(request)@routes.Profile.viewProfileUUID(user.id)" style="text-decoration: none">
                         <h2 style="margin: 0">@user.fullName</h2>
                     </a>
                 </td>

--- a/app/views/inviteThroughEmail.scala.html
+++ b/app/views/inviteThroughEmail.scala.html
@@ -5,8 +5,8 @@
 
         <p>Hello,</p>
 
-        <p>You have been invited to space @spaceName by @inviter at <a href="@routes.Application.index().absoluteURL(IdentityProvider.sslEnabled)">@services.AppConfiguration.getDisplayName</a>. Please follow this
-            <a href="@routes.Registration.signUp(token).absoluteURL(IdentityProvider.sslEnabled)">link</a> to accept this invitation.
+        <p>You have been invited to space @spaceName by @inviter at <a href="@controllers.Utils.baseUrl(request)@routes.Application.index()">@services.AppConfiguration.getDisplayName</a>. Please follow this
+            <a href="@controllers.Utils.baseUrl(request)@routes.Registration.signUp(token)">link</a> to accept this invitation.
         </p>
         <p>@message</p>
     </body>

--- a/app/views/spaces/inviteNotificationEmail.scala.html
+++ b/app/views/spaces/inviteNotificationEmail.scala.html
@@ -6,9 +6,9 @@
 
         <p>Hello @newmember,</p>
 
-        <p>You have been added by <a href="@routes.Profile.viewProfileUUID(inviter.id).absoluteURL(IdentityProvider.sslEnabled)">@inviter.fullName</a>
-            to @Messages("space.title") <a href="@routes.Spaces.getSpace(UUID(spaceid)).absoluteURL(IdentityProvider.sslEnabled)">@spaceName</a>
-            on <a href="@routes.Application.index().absoluteURL(IdentityProvider.sslEnabled)">@services.AppConfiguration.getDisplayName</a> as @role.
+        <p>You have been added by <a href="@controllers.Utils.baseUrl(request)@routes.Profile.viewProfileUUID(inviter.id)">@inviter.fullName</a>
+            to @Messages("space.title") <a href="@controllers.Utils.baseUrl(request)@routes.Spaces.getSpace(UUID(spaceid))">@spaceName</a>
+            on <a href="@controllers.Utils.baseUrl(request)@routes.Application.index()">@services.AppConfiguration.getDisplayName</a> as @role.
         </p>
     </body>
 </html>

--- a/app/views/spaces/requestemail.scala.html
+++ b/app/views/spaces/requestemail.scala.html
@@ -6,8 +6,8 @@
     <p>Hello,</p>
 
     <p>
-      <a href="@routes.Profile.viewProfileUUID(user.id).absoluteURL(IdentityProvider.sslEnabled)">@user.fullName</a> submitted an authorization request to your @Messages("space.title") "<a href="@routes.Spaces.getSpace(UUID(spaceid)).absoluteURL(IdentityProvider.sslEnabled)">@spacename</a>"
-      at <a href="@routes.Application.index().absoluteURL(IdentityProvider.sslEnabled)">@services.AppConfiguration.getDisplayName</a>.
+      <a href="@controllers.Utils.baseUrl(request)@routes.Profile.viewProfileUUID(user.id)">@user.fullName</a> submitted an authorization request to your @Messages("space.title") "<a href="@controllers.Utils.baseUrl(request)@routes.Spaces.getSpace(UUID(spaceid))">@spacename</a>"
+      at <a href="@controllers.Utils.baseUrl(request)@routes.Application.index()">@services.AppConfiguration.getDisplayName</a>.
     </p>
   </body>
 </html>

--- a/app/views/spaces/requestresponseemail.scala.html
+++ b/app/views/spaces/requestresponseemail.scala.html
@@ -6,8 +6,8 @@
     <p>Hello,</p>
 
     <p>
-      <a href="@routes.Profile.viewProfileUUID(user.id).absoluteURL(IdentityProvider.sslEnabled)">@user.fullName</a> @{requestmessage} @Messages("space.title") <a href="@routes.Spaces.getSpace(UUID(spaceid)).absoluteURL(IdentityProvider.sslEnabled)">@spacename</a>
-      at <a href="@routes.Application.index().absoluteURL(IdentityProvider.sslEnabled)">@services.AppConfiguration.getDisplayName</a>.
+      <a href="@controllers.Utils.baseUrl(request)@routes.Profile.viewProfileUUID(user.id)">@user.fullName</a> @{requestmessage} @Messages("space.title") <a href="@controllers.Utils.baseUrl(request)@routes.Spaces.getSpace(UUID(spaceid))">@spacename</a>
+      at <a href="@controllers.Utils.baseUrl(request)@routes.Application.index()">@services.AppConfiguration.getDisplayName</a>.
     </p>
     @if(requestmessage.contains("accept")) {
       <p>You can log in to view it.</p>

--- a/app/views/spaces/verifySpaceEmail.scala.html
+++ b/app/views/spaces/verifySpaceEmail.scala.html
@@ -6,7 +6,7 @@
 
     <p>Hello @member,</p>
 
-    <p>Congratulations, your @services.AppConfiguration.getDisplayName @Messages("space.title") <a href="@routes.Spaces.getSpace(UUID(spaceid)).absoluteURL(IdentityProvider.sslEnabled)">@spaceName</a> has been verified!
+    <p>Congratulations, your @services.AppConfiguration.getDisplayName @Messages("space.title") <a href="@controllers.Utils.baseUrl(request)@routes.Spaces.getSpace(UUID(spaceid))">@spaceName</a> has been verified!
       @play.api.i18n.Messages("verify.email.content")
     </p>
 

--- a/app/views/ss/Registration/resetPasswordPage.scala.html
+++ b/app/views/ss/Registration/resetPasswordPage.scala.html
@@ -19,7 +19,7 @@
             <p>@Messages("Please type in your new password with at least 8 characters and confirm it")</p>
         </div>
 
-        <form action="@securesocial.core.providers.utils.RoutesHelper.handleResetPassword(token).absoluteURL(IdentityProvider.sslEnabled)"
+        <form action="@controllers.Utils.baseUrl(request)@securesocial.core.providers.utils.RoutesHelper.handleResetPassword(token)"
               class="form-horizontal"
               autocomplete="off"
               method="POST"

--- a/app/views/ss/Registration/signUp.scala.html
+++ b/app/views/ss/Registration/signUp.scala.html
@@ -21,7 +21,7 @@
             <p>@Messages("Please enter your personal information to finish registration")</p>
         </div>
 
-        @*<form action="@securesocial.core.providers.utils.RoutesHelper.handleSignUp(token).absoluteURL(IdentityProvider.sslEnabled)"*@
+        @*<form action="@controllers.Utils.baseUrl(request)@securesocial.core.providers.utils.RoutesHelper.handleSignUp(token)"*@
       <form action = @routes.Registration.handleSignUp(token)
               class="form-horizontal"
               autocomplete= "off"

--- a/app/views/ss/Registration/startResetPassword.scala.html
+++ b/app/views/ss/Registration/startResetPassword.scala.html
@@ -19,7 +19,7 @@
             <p>@Messages("Please provide your email for further instructions")</p>
         </div>
 
-        <form action="@securesocial.core.providers.utils.RoutesHelper.handleStartResetPassword().absoluteURL(IdentityProvider.sslEnabled)"
+        <form action="@controllers.Utils.baseUrl(request)@securesocial.core.providers.utils.RoutesHelper.handleStartResetPassword()"
               class="form-horizontal"
               autocomplete="off"
               method="POST"

--- a/app/views/ss/Registration/startSignUp.scala.html
+++ b/app/views/ss/Registration/startSignUp.scala.html
@@ -19,7 +19,7 @@
             <p>@Messages("Please provide your email for further instructions")</p>
         </div>
 
-        <form action="@securesocial.core.providers.utils.RoutesHelper.handleStartSignUp().absoluteURL(IdentityProvider.sslEnabled)"
+        <form action="@controllers.Utils.baseUrl(request)@securesocial.core.providers.utils.RoutesHelper.handleStartSignUp()"
               class="form-horizontal"
               autocomplete="off" method="post"
         >

--- a/app/views/ss/mails/alreadyRegisteredEmail.scala.html
+++ b/app/views/ss/mails/alreadyRegisteredEmail.scala.html
@@ -5,8 +5,8 @@
     <body>
         <p>Hello @user.firstName,</p>
 
-        <p>You tried to sign up but you already have an account with us at <a href="@routes.Application.index().absoluteURL(IdentityProvider.sslEnabled)">@services.AppConfiguration.getDisplayName</a>.
-            If you don't remember your password please go <a href="@securesocial.core.providers.utils.RoutesHelper.startResetPassword().absoluteURL(IdentityProvider.sslEnabled)">here</a> to reset it.</p>
+        <p>You tried to sign up but you already have an account with us at <a href="@controllers.Utils.baseUrl(request)@routes.Application.index()">@services.AppConfiguration.getDisplayName</a>.
+            If you don't remember your password please go <a href="@controllers.Utils.baseUrl(request)@securesocial.core.providers.utils.RoutesHelper.startResetPassword()">here</a> to reset it.</p>
         @emails.footer()
     </body>
 </html>

--- a/app/views/ss/mails/passwordChangedNotice.scala.html
+++ b/app/views/ss/mails/passwordChangedNotice.scala.html
@@ -5,8 +5,8 @@
 <body>
 <p>Hello @user.firstName,</p>
 
-<p>Your password was updated at <a href="@routes.Application.index().absoluteURL(IdentityProvider.sslEnabled)">@services.AppConfiguration.getDisplayName</a>.
-    Please log in using your new password by clicking <a href="@securesocial.core.providers.utils.RoutesHelper.login.absoluteURL(IdentityProvider.sslEnabled)">here</a></p>
+<p>Your password was updated at <a href="@controllers.Utils.baseUrl(request)@routes.Application.index()">@services.AppConfiguration.getDisplayName</a>.
+    Please log in using your new password by clicking <a href="@controllers.Utils.baseUrl(request)@securesocial.core.providers.utils.RoutesHelper.login">here</a></p>
 @emails.footer()
 </body>
 </html>

--- a/app/views/ss/mails/passwordResetEmail.scala.html
+++ b/app/views/ss/mails/passwordResetEmail.scala.html
@@ -5,8 +5,8 @@
 <p>Hello @user.firstName,</p>
 
 <p>Please follow this
-    <a href="@securesocial.core.providers.utils.RoutesHelper.resetPassword(token).absoluteURL(IdentityProvider.sslEnabled)">
-    link</a> to reset your password on <a href="@routes.Application.index().absoluteURL(IdentityProvider.sslEnabled)">@services.AppConfiguration.getDisplayName</a>.
+    <a href="@controllers.Utils.baseUrl(request)@securesocial.core.providers.utils.RoutesHelper.resetPassword(token)">
+    link</a> to reset your password on <a href="@controllers.Utils.baseUrl(request)@routes.Application.index()">@services.AppConfiguration.getDisplayName</a>.
 </p>
 @emails.footer()
 </body>

--- a/app/views/ss/mails/signUpEmail.scala.html
+++ b/app/views/ss/mails/signUpEmail.scala.html
@@ -5,8 +5,8 @@
 <p>Hello,</p>
 
 <p>Please follow this
-    <a href="@securesocial.core.providers.utils.RoutesHelper.signUp(token).absoluteURL(IdentityProvider.sslEnabled)">link</a> to complete your registration
-    at <a href="@routes.Application.index().absoluteURL(IdentityProvider.sslEnabled)">@services.AppConfiguration.getDisplayName</a>.
+    <a href="@controllers.Utils.baseUrl(request)@securesocial.core.providers.utils.RoutesHelper.signUp(token)">link</a> to complete your registration
+    at <a href="@controllers.Utils.baseUrl(request)@routes.Application.index()">@services.AppConfiguration.getDisplayName</a>.
 </p>
 @emails.footer()
 </body>

--- a/app/views/ss/mails/unknownEmailNotice.scala.html
+++ b/app/views/ss/mails/unknownEmailNotice.scala.html
@@ -4,7 +4,7 @@
 <body>
 <p>Hello,</p>
 
-<p>We received a request to reset a password in our system at <a href="@routes.Application.index().absoluteURL(IdentityProvider.sslEnabled)">@services.AppConfiguration.getDisplayName</a>.  The attempt has failed because we do not have
+<p>We received a request to reset a password in our system at <a href="@controllers.Utils.baseUrl(request)@routes.Application.index()">@services.AppConfiguration.getDisplayName</a>.  The attempt has failed because we do not have
     a registered account with this email address. It could be that you logged in using an external account such as Twitter
     or Facebook.</p>
 

--- a/app/views/ss/mails/welcomeEmail.scala.html
+++ b/app/views/ss/mails/welcomeEmail.scala.html
@@ -8,8 +8,8 @@
 
         <p>
             Your new account is ready at
-            <a href="@routes.Application.index().absoluteURL(IdentityProvider.sslEnabled)"> @services.AppConfiguration.getDisplayName</a>.
-            Click <a href="@securesocial.core.providers.utils.RoutesHelper.login.absoluteURL(IdentityProvider.sslEnabled)">here</a>
+            <a href="@controllers.Utils.baseUrl(request)@routes.Application.index()"> @services.AppConfiguration.getDisplayName</a>.
+            Click <a href="@controllers.Utils.baseUrl(request)@securesocial.core.providers.utils.RoutesHelper.login">here</a>
             to log in
         </p>
 

--- a/app/views/ss/provider.scala.html
+++ b/app/views/ss/provider.scala.html
@@ -29,7 +29,7 @@
             }
 
             @if( provider.authMethod == UserPassword ) {
-                <form action = "@securesocial.core.providers.utils.RoutesHelper.authenticateByPost("userpass").absoluteURL(IdentityProvider.sslEnabled)"
+                <form action = "@controllers.Utils.baseUrl(request)@securesocial.core.providers.utils.RoutesHelper.authenticateByPost("userpass")"
                       class="form-horizontal" autocomplete="off" method="POST">
                     <fieldset>                                                    
                         @if( UsernamePasswordProvider.withUserNameSupport ) {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -44,6 +44,10 @@ ehcacheplugin = disabled
 # using proxy set this to the same path as the webserver path.
 #application.context="/clowder"
 
+# absolute URL to use for clowder, if set this will be used when an
+# url is needed to point to the server (for example in emails).
+#clowder.url="https://clowder.example.com/"
+
 # Intermediate extractor results cleanup time params (in hours)
 intermediateCleanup.checkEvery=1
 intermediateCleanup.removeAfter=24
@@ -192,9 +196,12 @@ mongodbURI = "mongodb://127.0.0.1:27017/clowder"
 clowder.rabbitmq.uri="amqp://guest:guest@localhost:5672/%2f"
 #clowder.rabbitmq.managmentPort=15672
 #clowder.rabbitmq.exchange=clowder
-# Following variable will use the url when sending messages over rabbitmq. This can be used in a docker
-# environment to force the use of a specific hostname when contacting clowder from the extractors. If
-# this is not specified the public URL of clowder will be used.
+
+# Following variable will use the url when sending messages over rabbitmq.
+# This can be used in a docker environment to force the use of a specific
+# hostname when contacting clowder from the extractors. If this is not
+# specified the public URL of clowder will be used. This will override
+# the value set using clowder.url.
 #clowder.rabbitmq.clowderurl=NONE
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -595,7 +602,9 @@ archiveAllowUnarchive=false
 #archiveExtractorId="ncsa.archival.s3"
 archiveExtractorId="ncsa.archival.disk"
 
-# NOTE: Setting interval to zero will disable automatic archiving
+# NOTE: Setting interval to zero will disable automatic archiving. To
+# use this make sure to either set clowder.rabbitmq.clowderurl or
+# clowder.url, otherwise this will not work.
 archiveAutoInterval=0                 # in seconds (e.g. 86400 == 24 hours)
 archiveAutoDelay=120                  # in seconds (e.g. 86400 == 24 hours)
 archiveAutoAfterInactiveCount=90      # NOTE: Setting count to zero will disable automatic archiving

--- a/conf/messages
+++ b/conf/messages
@@ -1,6 +1,6 @@
 profile.disclaimer=Your profile information is made available to repositories when data are published to them and, at the repository’s discretion, may be included with data publications that reference you (as the uploader, creator, or contact).
 trial.space=New Spaces are in trial mode, allowing you to take advantage of all Clowder functionality except making your data public. A Clowder team member will verify your Space shortly to make these additional capabilities possible.
-verify.email.contact.link=@routes.Application.email().absoluteURL(controllers.Utils.https(request))
+verify.email.contact.link=@@controllers.Utils.baseUrl(request)@routes.Application.email()
 verify.email.content=Your team now has access to the full suite of Clowder functionality, including publishing and making your data public.
 you.title= My {0}
 home.title=My {0}


### PR DESCRIPTION
## Description

This will allow you to set the URL for clowder. Anything that uses a absolute url will use this configuration option if available.

To test set in your custom.conf:
```
clowder.url=http://clowder.example.com:9000
```

And add to /etc/hosts:
```
127.0.0.1 clowder.example.com
```

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [X] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [X] I have updated the CHANGELOG.md.
- [ ] I have signed the CLA
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
