### PR TITLE
adding indexing for new collections created by the api route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## unreleased
+
+### Fixed
+- Collections created using api route are now indexed upon creation. [#257](https://github.com/clowder-framework/clowder/issues/257)
+
 ## 1.18.0 - 2021-07-08
 
 ### Added


### PR DESCRIPTION
## Description
In the collection api routes, newly created collections were not indexed with elasticsearch. This meant that when a script creates new collections, they would not be found via search.

## Review Time Estimate
- [x] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- 257 -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have updated the CHANGELOG.md.
- [x ] I have signed the CLA
- [ x] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] All new and existing tests passed.
