### PR TITLE
266 add when parameter in api datasets, collections and spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Added
+- Add "when" parameter in a few GET API endpoints to enable pagination [#266](https://github.com/clowder-framework/clowder/issues/266)
+
+
 ## 1.18.1 - 2021-08-16
 
 This release fixes a critical issue where invalid zip files could result in the files not being uploaded correctly. To check to see if you are affected, please use the following query:

--- a/app/api/Collections.scala
+++ b/app/api/Collections.scala
@@ -237,15 +237,15 @@ class Collections @Inject() (datasets: DatasetService,
     }
   }
 
-  def list(title: Option[String], date: Option[String], limit: Int, exact: Boolean) = PrivateServerAction { implicit request =>
-    Ok(toJson(listCollections(title, date, limit, Set[Permission](Permission.ViewCollection), false, request.user, request.user.fold(false)(_.superAdminMode), exact)))
+  def list(when: Option[String], title: Option[String], date: Option[String], limit: Int, exact: Boolean) = PrivateServerAction { implicit request =>
+    Ok(toJson(listCollections(when, title, date, limit, Set[Permission](Permission.ViewCollection), false, request.user, request.user.fold(false)(_.superAdminMode), exact)))
   }
 
-  def listCanEdit(title: Option[String], date: Option[String], limit: Int, exact: Boolean) = PrivateServerAction { implicit request =>
-    Ok(toJson(listCollections(title, date, limit, Set[Permission](Permission.AddResourceToCollection, Permission.EditCollection), false, request.user, request.user.fold(false)(_.superAdminMode), exact)))
+  def listCanEdit(when: Option[String], title: Option[String], date: Option[String], limit: Int, exact: Boolean) = PrivateServerAction { implicit request =>
+    Ok(toJson(listCollections(when, title, date, limit, Set[Permission](Permission.AddResourceToCollection, Permission.EditCollection), false, request.user, request.user.fold(false)(_.superAdminMode), exact)))
   }
 
-  def addDatasetToCollectionOptions(datasetId: UUID, title: Option[String], date: Option[String], limit: Int, exact: Boolean) = PrivateServerAction { implicit request =>
+  def addDatasetToCollectionOptions(when: Option[String], datasetId: UUID, title: Option[String], date: Option[String], limit: Int, exact: Boolean) = PrivateServerAction { implicit request =>
     implicit val user = request.user
     var listAll = false
     var collectionList: List[Collection] = List.empty
@@ -265,7 +265,7 @@ class Collections @Inject() (datasets: DatasetService,
       }
     }
     if(listAll) {
-      collectionList = listCollections(title, date, limit, Set[Permission](Permission.AddResourceToCollection, Permission.EditCollection), false, request.user, request.user.fold(false)(_.superAdminMode), exact)
+      collectionList = listCollections(when, title, date, limit, Set[Permission](Permission.AddResourceToCollection, Permission.EditCollection), false, request.user, request.user.fold(false)(_.superAdminMode), exact)
     }
     Ok(toJson(collectionList))
   }
@@ -274,10 +274,10 @@ class Collections @Inject() (datasets: DatasetService,
     collections.get(current_collections.map(_.child_collection_ids).flatten).found
   }
 
-  def listPossibleParents(currentCollectionId : String, title: Option[String], date: Option[String], limit: Int, exact: Boolean) = PrivateServerAction { implicit request =>
+  def listPossibleParents(when: Option[String], currentCollectionId : String, title: Option[String], date: Option[String], limit: Int, exact: Boolean) = PrivateServerAction { implicit request =>
     val selfAndAncestors = collections.getSelfAndAncestors(UUID(currentCollectionId))
     val descendants = collections.getAllDescendants(UUID(currentCollectionId)).toList
-    val allCollections = listCollections(title, date, limit, Set[Permission](Permission.AddResourceToCollection, Permission.EditCollection), false,
+    val allCollections = listCollections(when, title, date, limit, Set[Permission](Permission.AddResourceToCollection, Permission.EditCollection), false,
       request.user, request.user.fold(false)(_.superAdminMode), exact)
     val possibleNewParents = allCollections.filter(c =>
       if(play.api.Play.current.plugin[services.SpaceSharingPlugin].isDefined) {
@@ -303,29 +303,55 @@ class Collections @Inject() (datasets: DatasetService,
    * Returns list of collections based on parameters and permissions.
    * TODO this needs to be cleaned up when do permissions for adding to a resource
    */
-  private def listCollections(title: Option[String], date: Option[String], limit: Int, permission: Set[Permission], mine: Boolean, user: Option[User], superAdmin: Boolean, exact: Boolean) : List[Collection] = {
+  private def listCollections(when: Option[String], title: Option[String], date: Option[String], limit: Int, permission: Set[Permission], mine: Boolean, user: Option[User], superAdmin: Boolean, exact: Boolean) : List[Collection] = {
     if (mine && user.isEmpty) return List.empty[Collection]
 
-    (title, date) match {
-      case (Some(t), Some(d)) => {
+    (when, title, date) match {
+      case (Some(w), Some(t), Some(d)) => {
         if (mine)
-          collections.listUser(d, true, limit, t, user, superAdmin, user.get, exact)
+          collections.listUser(d, nextPage=(w=="a"), limit, t, user, superAdmin, user.get, exact)
         else
-          collections.listAccess(d, true, limit, t, permission, user, superAdmin, true,false, exact)
+          collections.listAccess(d, nextPage=(w=="a"), limit, t, permission, user, superAdmin, true,false, exact)
       }
-      case (Some(t), None) => {
+      case (Some(w), Some(t), None) => {
         if (mine)
           collections.listUser(limit, t, user, superAdmin, user.get, exact)
         else
           collections.listAccess(limit, t, permission, user, superAdmin, true,false, exact)
       }
-      case (None, Some(d)) => {
+      case (Some(w), None, Some(d)) => {
+        if (mine)
+          collections.listUser(d, nextPage=(w=="a"), limit, user, superAdmin, user.get)
+        else
+          collections.listAccess(d, nextPage=(w=="a"), limit, permission, user, superAdmin, true,false)
+      }
+       case (Some(w), None, None) => {
+        if (mine)
+          collections.listUser(limit, user, superAdmin, user.get)
+        else
+          collections.listAccess(limit, permission, user, superAdmin, true,false)
+      }
+
+      // default when to be "after" if not present in parameters. i.e. nextPage=true
+      case (None, Some(t), Some(d)) => {
+        if (mine)
+          collections.listUser(d, true, limit, t, user, superAdmin, user.get, exact)
+        else
+          collections.listAccess(d, true, limit, t, permission, user, superAdmin, true,false, exact)
+      }
+      case (None, Some(t), None) => {
+        if (mine)
+          collections.listUser(limit, t, user, superAdmin, user.get, exact)
+        else
+          collections.listAccess(limit, t, permission, user, superAdmin, true,false, exact)
+      }
+      case (None, None, Some(d)) => {
         if (mine)
           collections.listUser(d, true, limit, user, superAdmin, user.get)
         else
           collections.listAccess(d, true, limit, permission, user, superAdmin, true,false)
       }
-       case (None, None) => {
+      case (None, None, None) => {
         if (mine)
           collections.listUser(limit, user, superAdmin, user.get)
         else

--- a/app/api/Datasets.scala
+++ b/app/api/Datasets.scala
@@ -65,19 +65,19 @@ class  Datasets @Inject()(
     }
   }
 
-  def list(title: Option[String], date: Option[String], limit: Int, exact: Boolean) = PrivateServerAction { implicit request =>
-    Ok(toJson(listDatasets(title, date, limit, Set[Permission](Permission.ViewDataset), request.user, request.user.fold(false)(_.superAdminMode), exact)))
+  def list(when: Option[String], title: Option[String], date: Option[String], limit: Int, exact: Boolean) = PrivateServerAction { implicit request =>
+    Ok(toJson(listDatasets(when, title, date, limit, Set[Permission](Permission.ViewDataset), request.user, request.user.fold(false)(_.superAdminMode), exact)))
   }
 
-  def listCanEdit(title: Option[String], date: Option[String], limit: Int, exact: Boolean) = PrivateServerAction { implicit request =>
-      Ok(toJson(listDatasets(title, date, limit, Set[Permission](Permission.AddResourceToDataset, Permission.EditDataset), request.user, request.user.fold(false)(_.superAdminMode), exact)))
+  def listCanEdit(when: Option[String], title: Option[String], date: Option[String], limit: Int, exact: Boolean) = PrivateServerAction { implicit request =>
+      Ok(toJson(listDatasets(when, title, date, limit, Set[Permission](Permission.AddResourceToDataset, Permission.EditDataset), request.user, request.user.fold(false)(_.superAdminMode), exact)))
   }
 
   def listMoveFileToDataset(file_id: UUID, title: Option[String], limit: Int, exact: Boolean) = PrivateServerAction { implicit request =>
     if (play.Play.application().configuration().getBoolean("datasetFileWithinSpace")) {
       Ok(toJson(listDatasetsInSpace(file_id, title, limit, Set[Permission](Permission.AddResourceToDataset, Permission.EditDataset), request.user, request.user.fold(false)(_.superAdminMode), exact)))
     } else {
-      Ok(toJson(listDatasets(title, None, limit, Set[Permission](Permission.AddResourceToDataset, Permission.EditDataset), request.user, request.user.fold(false)(_.superAdminMode), exact)))
+      Ok(toJson(listDatasets(None, title, None, limit, Set[Permission](Permission.AddResourceToDataset, Permission.EditDataset), request.user, request.user.fold(false)(_.superAdminMode), exact)))
     }
   }
 
@@ -152,18 +152,31 @@ class  Datasets @Inject()(
   /**
     * Returns list of datasets based on parameters and permissions.
     */
-  private def listDatasets(title: Option[String], date: Option[String], limit: Int, permission: Set[Permission], user: Option[User], superAdmin: Boolean, exact: Boolean) : List[Dataset] = {
-    (title, date) match {
-      case (Some(t), Some(d)) => {
-        datasets.listAccess(d, true, limit, t, permission, user, superAdmin, true,false, exact)
+  private def listDatasets(when: Option[String], title: Option[String], date: Option[String], limit: Int, permission: Set[Permission], user: Option[User], superAdmin: Boolean, exact: Boolean) : List[Dataset] = {
+    (when, title, date) match {
+      case (Some(when), Some(t), Some(d)) => {
+        datasets.listAccess(d, nextPage=(when=="a"), limit, t, permission, user, superAdmin, true,false, exact)
       }
-      case (Some(t), None) => {
+      case (Some(when), Some(t), None) => {
         datasets.listAccess(limit, t, permission, user, superAdmin, true,false, exact)
       }
-      case (None, Some(d)) => {
+      case (Some(when), None, Some(d)) => {
+        datasets.listAccess(d, nextPage=(when=="a"), limit, permission, user, superAdmin, true,false)
+      }
+      case (Some(when), None, None) => {
+        datasets.listAccess(limit, permission, user, superAdmin, true,false)
+      }
+      // default when to be "after" if not present in parameters. i.e. nextPage=true
+      case (None, Some(t), Some(d)) => {
+        datasets.listAccess(d, true, limit, t, permission, user, superAdmin, true,false, exact)
+      }
+      case (None, Some(t), None) => {
+        datasets.listAccess(limit, t, permission, user, superAdmin, true,false, exact)
+      }
+      case (None, None, Some(d)) => {
         datasets.listAccess(d, true, limit, permission, user, superAdmin, true,false)
       }
-      case (None, None) => {
+      case (None, None, None) => {
         datasets.listAccess(limit, permission, user, superAdmin, true,false)
       }
     }

--- a/app/api/Datasets.scala
+++ b/app/api/Datasets.scala
@@ -154,16 +154,16 @@ class  Datasets @Inject()(
     */
   private def listDatasets(when: Option[String], title: Option[String], date: Option[String], limit: Int, permission: Set[Permission], user: Option[User], superAdmin: Boolean, exact: Boolean) : List[Dataset] = {
     (when, title, date) match {
-      case (Some(when), Some(t), Some(d)) => {
-        datasets.listAccess(d, nextPage=(when=="a"), limit, t, permission, user, superAdmin, true,false, exact)
+      case (Some(w), Some(t), Some(d)) => {
+        datasets.listAccess(d, nextPage=(w=="a"), limit, t, permission, user, superAdmin, true,false, exact)
       }
-      case (Some(when), Some(t), None) => {
+      case (Some(w), Some(t), None) => {
         datasets.listAccess(limit, t, permission, user, superAdmin, true,false, exact)
       }
-      case (Some(when), None, Some(d)) => {
-        datasets.listAccess(d, nextPage=(when=="a"), limit, permission, user, superAdmin, true,false)
+      case (Some(w), None, Some(d)) => {
+        datasets.listAccess(d, nextPage=(w=="a"), limit, permission, user, superAdmin, true,false)
       }
-      case (Some(when), None, None) => {
+      case (Some(w), None, None) => {
         datasets.listAccess(limit, permission, user, superAdmin, true,false)
       }
       // default when to be "after" if not present in parameters. i.e. nextPage=true

--- a/app/api/Spaces.scala
+++ b/app/api/Spaces.scala
@@ -86,45 +86,70 @@ class Spaces @Inject()(spaces: SpaceService,
     }
   }
 
-  def list(title: Option[String], date: Option[String], limit: Int) = UserAction(needActive=false) { implicit request =>
-    Ok(toJson(listSpaces(title, date, limit, Set[Permission](Permission.ViewSpace), false, request.user, request.user.fold(false)(_.superAdminMode), true).map(spaceToJson)))
+  def list(when: Option[String], title: Option[String], date: Option[String], limit: Int) = UserAction(needActive=false) { implicit request =>
+    Ok(toJson(listSpaces(when, title, date, limit, Set[Permission](Permission.ViewSpace), false, request.user, request.user.fold(false)(_.superAdminMode), true).map(spaceToJson)))
   }
 
-  def listCanEdit(title: Option[String], date: Option[String], limit: Int) = UserAction(needActive=true) { implicit request =>
-    Ok(toJson(listSpaces(title, date, limit, Set[Permission](Permission.AddResourceToSpace, Permission.EditSpace), false, request.user, request.user.fold(false)(_.superAdminMode), true).map(spaceToJson)))
+  def listCanEdit(when: Option[String], title: Option[String], date: Option[String], limit: Int) = UserAction(needActive=true) { implicit request =>
+    Ok(toJson(listSpaces(when, title, date, limit, Set[Permission](Permission.AddResourceToSpace, Permission.EditSpace), false, request.user, request.user.fold(false)(_.superAdminMode), true).map(spaceToJson)))
   }
 
-  def listCanEditNotAlreadyIn(collectionId : UUID, title: Option[String], date: Option[String], limit: Int) = UserAction(needActive=true ){ implicit request =>
-    Ok(toJson(listSpaces(title, date, limit, Set[Permission](Permission.AddResourceToSpace, Permission.EditSpace), false, request.user, request.user.fold(false)(_.superAdminMode), true).map(spaceToJson)))
+  def listCanEditNotAlreadyIn(when: Option[String], collectionId : UUID, title: Option[String], date: Option[String], limit: Int) = UserAction(needActive=true ){ implicit request =>
+    Ok(toJson(listSpaces(when, title, date, limit, Set[Permission](Permission.AddResourceToSpace, Permission.EditSpace), false, request.user, request.user.fold(false)(_.superAdminMode), true).map(spaceToJson)))
   }
 
   /**
    * Returns list of collections based on parameters and permissions.
    * TODO this needs to be cleaned up when do permissions for adding to a resource
    */
-  private def listSpaces(title: Option[String], date: Option[String], limit: Int, permission: Set[Permission], mine: Boolean, user: Option[User], superAdmin: Boolean, showPublic: Boolean, onlyTrial: Boolean = false) : List[ProjectSpace] = {
+  private def listSpaces(when: Option[String], title: Option[String], date: Option[String], limit: Int, permission: Set[Permission], mine: Boolean, user: Option[User], superAdmin: Boolean, showPublic: Boolean, onlyTrial: Boolean = false) : List[ProjectSpace] = {
     if (mine && user.isEmpty) return List.empty[ProjectSpace]
 
-    (title, date) match {
-      case (Some(t), Some(d)) => {
+    (when, title, date) match {
+      case (Some(w), Some(t), Some(d)) => {
         if (mine)
-          spaces.listUser(d, true, limit, t, user, superAdmin, user.get)
+          spaces.listUser(d, nextPage=(w=="a"), limit, t, user, superAdmin, user.get)
         else
-          spaces.listAccess(d, true, limit, t, permission, user, superAdmin, showPublic, showOnlyShared = false)
+          spaces.listAccess(d, nextPage=(w=="a"), limit, t, permission, user, superAdmin, showPublic, showOnlyShared = false)
       }
-      case (Some(t), None) => {
+      case (Some(w), Some(t), None) => {
         if (mine)
           spaces.listUser(limit, t, user, superAdmin, user.get)
         else
           spaces.listAccess(limit, t, permission, user, superAdmin, showPublic, showOnlyShared = false)
       }
-      case (None, Some(d)) => {
+      case (Some(w), None, Some(d)) => {
+        if (mine)
+          spaces.listUser(d, nextPage=(w=="a"), limit, user, superAdmin, user.get)
+        else
+          spaces.listAccess(d, nextPage=(w=="a"), limit, permission, user, superAdmin, showPublic, onlyTrial, showOnlyShared = false)
+      }
+      case (Some(w), None, None) => {
+        if (mine)
+          spaces.listUser(limit, user, superAdmin, user.get)
+        else
+          spaces.listAccess(limit, permission, user, superAdmin, showPublic, onlyTrial, showOnlyShared = false)
+      }
+      // default when to be "after" if not present in parameters. i.e. nextPage=true
+      case (None, Some(t), Some(d)) => {
+        if (mine)
+          spaces.listUser(d, true, limit, t, user, superAdmin, user.get)
+        else
+          spaces.listAccess(d, true, limit, t, permission, user, superAdmin, showPublic, showOnlyShared = false)
+      }
+      case (None, Some(t), None) => {
+        if (mine)
+          spaces.listUser(limit, t, user, superAdmin, user.get)
+        else
+          spaces.listAccess(limit, t, permission, user, superAdmin, showPublic, showOnlyShared = false)
+      }
+      case (None, None, Some(d)) => {
         if (mine)
           spaces.listUser(d, true, limit, user, superAdmin, user.get)
         else
           spaces.listAccess(d, true, limit, permission, user, superAdmin, showPublic, onlyTrial, showOnlyShared = false)
       }
-      case (None, None) => {
+      case (None, None, None) => {
         if (mine)
           spaces.listUser(limit, user, superAdmin, user.get)
         else

--- a/conf/routes
+++ b/conf/routes
@@ -555,8 +555,8 @@ GET            /api/collections/:coll_id/removeFromSpaceAllowed/:space_id       
 # ----------------------------------------------------------------------
 # DATASETS ENDPOINT
 # ----------------------------------------------------------------------
-GET            /api/datasets                                                            @api.Datasets.list(title: Option[String] ?= None, date: Option[String] ?= None, limit: Int ?= 12, exact: Boolean ?= false)
-GET            /api/datasets/canEdit                                                    @api.Datasets.listCanEdit(title: Option[String] ?= None, date: Option[String] ?= None, limit: Int ?= 12, exact: Boolean ?= false)
+GET            /api/datasets                                                            @api.Datasets.list(when: Option[String] ?= None, title: Option[String] ?= None, date: Option[String] ?= None, limit: Int ?= 12, exact: Boolean ?= false)
+GET            /api/datasets/canEdit                                                    @api.Datasets.listCanEdit(when: Option[String] ?= None, title: Option[String] ?= None, date: Option[String] ?= None, limit: Int ?= 12, exact: Boolean ?= false)
 GET            /api/datasets/moveFileToDataset                                          @api.Datasets.listMoveFileToDataset(file_id: UUID, title: Option[String] ?= None, limit: Int ?= 12, exact: Boolean ?= false)
 POST           /api/datasets                                                            @api.Datasets.createDataset
 POST           /api/datasets/createempty                                                @api.Datasets.createEmptyDataset

--- a/conf/routes
+++ b/conf/routes
@@ -484,8 +484,8 @@ GET            /api/files/:three_d_file_id/:filename                            
 # ----------------------------------------------------------------------
 # SPACES ENDPOINT
 # ----------------------------------------------------------------------
-GET            /api/spaces                                                              @api.Spaces.list(title: Option[String] ?= None, date: Option[String] ?= None, limit: Int ?= 12)
-GET            /api/spaces/canEdit                                                      @api.Spaces.listCanEdit(title: Option[String] ?= None, date: Option[String] ?= None, limit: Int ?= 12)
+GET            /api/spaces                                                              @api.Spaces.list(when: Option[String] ?= None, title: Option[String] ?= None, date: Option[String] ?= None, limit: Int ?= 12)
+GET            /api/spaces/canEdit                                                      @api.Spaces.listCanEdit(when: Option[String] ?= None, title: Option[String] ?= None, date: Option[String] ?= None, limit: Int ?= 12)
 GET            /api/spaces/:id                                                          @api.Spaces.get(id: UUID)
 POST           /api/spaces                                                              @api.Spaces.createSpace()
 DELETE         /api/spaces/:id                                                          @api.Spaces.removeSpace(id: UUID)
@@ -508,10 +508,10 @@ GET            /api/spaces/:id/collections                                      
 # ----------------------------------------------------------------------
 # COLLECTIONS ENDPOINT
 # ----------------------------------------------------------------------
-GET            /api/collections                                                         @api.Collections.list(title: Option[String] ?= None, date: Option[String] ?= None, limit: Int ?= 12, exact: Boolean ?= false)
-GET            /api/collections/canEdit                                                 @api.Collections.listCanEdit(title: Option[String] ?= None, date: Option[String] ?= None, limit: Int ?= 12, exact: Boolean ?= false)
-GET            /api/collections/datasetPossibleParents/:ds_id                           @api.Collections.addDatasetToCollectionOptions(ds_id: UUID, title: Option[String]?= None, date: Option[String] ?= None, limit: Int ?= 12, exact: Boolean ?= false)
-GET            /api/collections/possibleParents                                         @api.Collections.listPossibleParents(currentCollectionId: String, title: Option[String] ?= None, date: Option[String] ?= None, limit: Int ?= 12, exact: Boolean ?= false)
+GET            /api/collections                                                         @api.Collections.list(when: Option[String] ?= None, title: Option[String] ?= None, date: Option[String] ?= None, limit: Int ?= 12, exact: Boolean ?= false)
+GET            /api/collections/canEdit                                                 @api.Collections.listCanEdit(when: Option[String] ?= None, title: Option[String] ?= None, date: Option[String] ?= None, limit: Int ?= 12, exact: Boolean ?= false)
+GET            /api/collections/datasetPossibleParents/:ds_id                           @api.Collections.addDatasetToCollectionOptions(when: Option[String] ?= None, ds_id: UUID, title: Option[String]?= None, date: Option[String] ?= None, limit: Int ?= 12, exact: Boolean ?= false)
+GET            /api/collections/possibleParents                                         @api.Collections.listPossibleParents(when: Option[String] ?= None, currentCollectionId: String, title: Option[String] ?= None, date: Option[String] ?= None, limit: Int ?= 12, exact: Boolean ?= false)
 POST           /api/collections                                                         @api.Collections.createCollection()
 GET            /api/collections/rootCollections                                         @api.Collections.getRootCollections
 GET            /api/collections/topLevelCollections                                     @api.Collections.getTopLevelCollections
@@ -522,7 +522,7 @@ DELETE         /api/collections/emptyTrash                                      
 DELETE         /api/collections/clearOldCollectionsTrash                                @api.Collections.clearOldCollectionsTrash(days : Int ?= 30)
 PUT            /api/collections/restore/:collectionId                                   @api.Collections.restoreCollection(collectionId : UUID)
 # deprecrated
-GET            /api/collections/list                                                    @api.Collections.list(title: Option[String] ?= None, date: Option[String] ?= None, limit: Int ?= 12, exact: Boolean ?= false)
+GET            /api/collections/list                                                    @api.Collections.list(when: Option[String] ?= None, title: Option[String] ?= None, date: Option[String] ?= None, limit: Int ?= 12, exact: Boolean ?= false)
 POST           /api/collections/:id/follow                                              @api.Collections.follow(id: UUID)
 POST           /api/collections/:id/unfollow                                            @api.Collections.unfollow(id: UUID)
 GET            /api/collections/:coll_id/datasets                                       @api.Datasets.listInCollection(coll_id: UUID)

--- a/public/swagger.yml
+++ b/public/swagger.yml
@@ -1768,6 +1768,22 @@ paths:
         - datasets
       summary: List all datasets the user can view
       description: This will check for Permission.ViewDataset
+      parameters:
+        - name: when
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: date
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: title
+          in: query
+          required: false
+          schema:
+            type: string
       responses:
         200:
           description: OK
@@ -2622,6 +2638,22 @@ paths:
       description: |
         This will check for Permission.AddResourceToDataset and
         Permission.EditDataset
+      parameters:
+        - name: when
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: date
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: title
+          in: query
+          required: false
+          schema:
+            type: string
       responses:
         200:
           description: OK
@@ -3346,6 +3378,11 @@ paths:
         view permission
       description: Collections are groupings of datasets
       parameters:
+        - name: when
+          in: query
+          required: false
+          schema:
+            type: string
         - name: title
           in: query
           description: The title/ name of colletions
@@ -3497,6 +3534,11 @@ paths:
         This will check for Permission.AddResourceToCollection and
         Permission.EditCollection
       parameters:
+        - name: when
+          in: query
+          required: false
+          schema:
+            type: string
         - name: currentCollectionId
           in: query
           required: true
@@ -3595,6 +3637,11 @@ paths:
         This will check for Permission.AddResourceToCollection and
         Permission.EditCollection
       parameters:
+        - name: when
+          in: query
+          required: false
+          schema:
+            type: string
         - name: title
           in: query
           schema:
@@ -4092,6 +4139,11 @@ paths:
       summary: List all collections the user can view
       description: This will check for Permission.ViewCollection
       parameters:
+        - name: when
+          in: query
+          required: false
+          schema:
+            type: string
         - name: title
           in: query
           schema:
@@ -4168,6 +4220,11 @@ paths:
       summary: List spaces the user can view
       description: Retrieves information about spaces
       parameters:
+        - name: when
+          in: query
+          required: false
+          schema:
+            type: string
         - name: title
           in: query
           schema:
@@ -4454,6 +4511,25 @@ paths:
       summary: List spaces the user can add to
       description: Retrieves a list of spaces that the user has permission to add
         to
+      parameters:
+        - name: when
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: title
+          in: query
+          schema:
+            type: string
+        - name: date
+          in: query
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: default as 12
+          schema:
+            type: number
       responses:
         200:
           description: OK

--- a/public/swagger.yml
+++ b/public/swagger.yml
@@ -1784,6 +1784,15 @@ paths:
           required: false
           schema:
             type: string
+        - name: limit
+          in: query
+          description: The number of collections returns, default as 12.
+          schema:
+            type: integer
+        - name: exact
+          in: query
+          schema:
+            type: boolean
       responses:
         200:
           description: OK
@@ -2654,6 +2663,15 @@ paths:
           required: false
           schema:
             type: string
+        - name: limit
+          in: query
+          description: The number of collections returns, default as 12.
+          schema:
+            type: integer
+        - name: exact
+          in: query
+          schema:
+            type: boolean
       responses:
         200:
           description: OK

--- a/public/swagger.yml
+++ b/public/swagger.yml
@@ -3805,6 +3805,11 @@ paths:
         the dataset in this space, otherwise list all possiable collections
       description: Collections are groupings of datasets
       parameters:
+        - name: when
+          in: query
+          required: false
+          schema:
+            type: string
         - name: coll_id
           in: path
           required: true


### PR DESCRIPTION
## Description
add "when" parameter in below endpoints:
```
GET /api/datasets
GET /api/datasets/canEdit

GET /api/collections
GET /api/collections/canEdit  
GET /api/collections/possibleParents
GET /api/collections/{coll_id}/datasetPossibleParents/{ds_id}
GET /api/collections/list 

GET /api/spaces
GET /api/spaces/canEdit
```
## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [x] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have signed the CLA
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
