### PR TITLE
Bugfix/274 cannot add dataset to space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ### Fixed
+- Can add dataset to spaces - fixed error when no spaces would load. [#274](https://github.com/clowder-framework/clowder/issues/274)
 - Typos "success" when returning status from API and "occurred" when logging to console.
 
 ### Added

--- a/app/views/spaces/spaceSelect.scala.html
+++ b/app/views/spaces/spaceSelect.scala.html
@@ -27,7 +27,7 @@
             allowClear: true,
             ajax: {
                 url: function(params) {
-                    return jsRoutes.api.Spaces.listCanEdit(params.term, null, 5).url;
+                    return jsRoutes.api.Spaces.listCanEdit(params.term, null, null, 5).url;
                 },
                 data: function(params) {
                     return { title: params.term };


### PR DESCRIPTION
## Description
I found that if you went to a dataset page, if you wanted to add it to a space no spaces would be returned in the dropdown due to an error. "5" was being passed in as the date in api.spacesListCanEdit instead of the limit. 

To fix I only added one extra null for the Option[Date]

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [ x] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x ] I have updated the CHANGELOG.md.
- [ x] I have signed the CLA
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
