### PR TITLE
add id in GET /metadata.jsonld responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Add "when" parameter in a few GET API endpoints to enable pagination [#266](https://github.com/clowder-framework/clowder/issues/266)
+- Add "id" in GET metadata.jsonld endpoints [#278](https://github.com/clowder-framework/clowder/issues/278)
 
 ## 1.18.1 - 2021-08-16
 

--- a/app/util/JSONLD.scala
+++ b/app/util/JSONLD.scala
@@ -64,7 +64,7 @@ object JSONLD {
 
     //convert metadata to json using implicit writes in Metadata model
     //include metadata ID in the json
-    val metadataJson = resourceJson ++ toJson(metadata).asInstanceOf[JsObject] ++ JsObject(Seq("id" -> JsString(metadata.id.toString())))
+    val metadataJson = JsObject(Seq("id" -> JsString(metadata.id.toString()))) ++ resourceJson ++ toJson(metadata).asInstanceOf[JsObject]
 
     //combine the two json objects and return
     if (contextJson.isEmpty) metadataJson else contextJson.get ++ metadataJson

--- a/app/util/JSONLD.scala
+++ b/app/util/JSONLD.scala
@@ -63,7 +63,8 @@ object JSONLD {
     )
 
     //convert metadata to json using implicit writes in Metadata model
-    val metadataJson = resourceJson ++ toJson(metadata).asInstanceOf[JsObject]
+    //include metadata ID in the json
+    val metadataJson = resourceJson ++ toJson(metadata).asInstanceOf[JsObject] ++ JsObject(Seq("id" -> JsString(metadata.id.toString())))
 
     //combine the two json objects and return
     if (contextJson.isEmpty) metadataJson else contextJson.get ++ metadataJson


### PR DESCRIPTION
## Description
add `id` field in response of :
```
GET /api/datasets/{id}/metadata.jsonld
GET /api/files/{id}/metadata.jsonld

GET /api/files/metadata.jsonld?id=xxx&id=xxx
```

Now you should see an `id` field in the return
e.g.
```
{
        "@context": [
            "https://clowderframework.org/contexts/metadata.jsonld",
            {
                "Funding Institution": "http://sead-data.net/terms/FundingInstitution"
            }
        ],
        "attached_to": {
            "resource_type": "cat:file",
            "url": "http://localhost:9000/files/6101852f19ec54b93cb07ff1"
        },
        "created_at": "Fri Sep 24 16:39:36 CDT 2021",
        "agent": {
            "@type": "cat:user",
            "name": "Chen Wang",
            "user_id": "http://localhost:9000/api/users/610183f740d74ef84576680d"
        },
        "content": {
            "Funding Institution": "ncsa"
        },
        "id": "614e459819ec1c778a5ffd7b"
    },
```

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [x] Immediately
- [x] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the CHANGELOG.md.
- [ ] I have signed the CLA
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
