### PR TITLE
#277 dataset thumbnail 404 not found   broken link after file deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Can add dataset to spaces - fixed error when no spaces would load. [#274](https://github.com/clowder-framework/clowder/issues/274)
 - Typos "success" when returning status from API and "occurred" when logging to console.
 - If a dataset had multiple folders the layout would be wrong.
+- Fix the broken link after file deletion within a folder. [#277](https://github.com/clowder-framework/clowder/issues/277) 
 
 ### Added
 - Adding mime type for geojson

--- a/app/api/Folders.scala
+++ b/app/api/Folders.scala
@@ -333,8 +333,6 @@ class Folders @Inject() (
                             })
                           }
                         }
-                          }
-                        }
 
                         files.index(fileId)
                         datasets.index(datasetId)

--- a/app/api/Folders.scala
+++ b/app/api/Folders.scala
@@ -22,6 +22,7 @@ import scala.collection.mutable.ListBuffer
 class Folders @Inject() (
   folders: FolderService,
   datasets: DatasetService,
+  collections: CollectionService,
   files: FileService,
   events: EventService,
   routing: ExtractorRoutingService) extends ApiController {
@@ -316,6 +317,25 @@ class Folders @Inject() (
                       if(dataset.files.contains(fileId)) {
                         folders.addFile(newFolder.id, fileId)
                         datasets.removeFile(datasetId, fileId)
+
+                        // when moving a file in the root of a dataset inside a folder
+                        // check if that file has been used as thumbnail
+                        // if yes, update the thumbnail of both dataset and collection
+                        if(!file.thumbnail_id.isEmpty && !dataset.thumbnail_id.isEmpty){
+                          if (file.thumbnail_id.get.equals(dataset.thumbnail_id.get)){
+                            datasets.newThumbnail(dataset.id)
+                            collections.get(dataset.collections).found.foreach(collection => {
+                              if(!collection.thumbnail_id.isEmpty){
+                                if(collection.thumbnail_id.get.equals(dataset.thumbnail_id.get)){
+                                  collections.createThumbnail(collection.id)
+                                }
+                              }
+                            })
+                          }
+                        }
+                          }
+                        }
+
                         files.index(fileId)
                         datasets.index(datasetId)
                         Ok(toJson(Map("status" -> "success", "fileName" -> file.filename, "folderName" -> newFolder.name)))


### PR DESCRIPTION
## Description

### First to reproduce this issue, see the latest comment I made at the issue #277 

In short, deleting a file used as thumbnail **IS FINE** :-p. 

Only when that image (used as thumbnail) is moved to a folder  --> then got deleted causes issues. The reason is being that images inside of the folder are NOT used as thumbnail candidates at the moment; however when moving an existing thumbnail to the folder failed to update that dataset/collection.

To fix that I added additional logic when **move file to folders**

---------
###  To test try below steps:

1. Upload 2 images to the root dataset - _you should see the first image being used as thumbnail of the dataset_
2. Create a folder
3. Move one of the image to the folder - _you should see the thumbnail of the dataset changed_
4. Move the other image to the folder - _you should see the dataset is without thumbnail anymore_
5. Delete folder/ or delete images inside of the folder - _should not be any broken links_

you could repeat the above step with dataset within collections, you should see similar results for the collection thumbnail. 


## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [x] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] I have signed the CLA
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
