### PR TITLE
rolles back aws libraries to known working version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.19.2 - 2021-10-20
+
+### Fixed
+- Error with library dependencies broke search capabilities, rolled back to known working versions
+
 ## 1.19.1 - 2021-10-19
 
 ### Added

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -125,11 +125,11 @@ object ApplicationBuild extends Build {
     "org.julienrf" %% "play-jsonp-filter" % "1.1",
 
     // Official AWS Java SDK
-    "com.amazonaws" % "aws-java-sdk-bom" % "1.12.78",
+    "com.amazonaws" % "aws-java-sdk-bom" % "1.11.106",
 
-    "com.amazonaws" % "aws-java-sdk-s3" % "1.12.78",
+    "com.amazonaws" % "aws-java-sdk-s3" % "1.11.106",
 
-    "com.amazonaws" % "aws-java-sdk-sts" % "1.12.78"
+    "com.amazonaws" % "aws-java-sdk-sts" % "1.11.106"
   )
 
   // Only compile the bootstrap bootstrap.less file and any other *.less file in the stylesheets directory


### PR DESCRIPTION
## Description

AWS libraries woud pull in some of com.fasterxml 2.12.3, but not all. This broke search that needs 2.6.6. 

Rolled back aws libraries

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [X] Immediately
- [ ] Within one week
- [ ] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [X] I have updated the CHANGELOG.md.
- [ ] I have signed the CLA
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
