### PR TITLE
consistent spelling of BagIt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+- conf file and code had incosistent spelling of BagIt. Now all have capital B and I.
+
 ## 1.19.5 - 2022-01-21
 
 ### Fixed

--- a/app/api/Collections.scala
+++ b/app/api/Collections.scala
@@ -805,7 +805,7 @@ class Collections @Inject() (datasets: DatasetService,
     implicit val user = request.user
     collections.get(id) match {
       case Some(collection) => {
-        val bagit = play.api.Play.configuration.getBoolean("downloadCollectionBagit").getOrElse(true)
+        val bagit = play.api.Play.configuration.getBoolean("downloadCollectionBagIt").getOrElse(true)
         // Use custom enumerator to create the zip file on the fly
         // Use a 1MB in memory byte array
         Ok.chunked(enumeratorFromCollection(collection,1024*1024, compression,bagit,user)).withHeaders(

--- a/app/api/Datasets.scala
+++ b/app/api/Datasets.scala
@@ -2838,7 +2838,7 @@ class  Datasets @Inject()(
     implicit val user = request.user
     datasets.get(id) match {
       case Some(dataset) => {
-        val bagit = play.api.Play.configuration.getBoolean("downloadDatasetBagit").getOrElse(true)
+        val bagit = play.api.Play.configuration.getBoolean("downloadDatasetBagIt").getOrElse(true)
         val baseURL = controllers.routes.Datasets.dataset(id).absoluteURL(https(request))
 
         // Increment download count if tracking is enabled
@@ -2867,7 +2867,7 @@ class  Datasets @Inject()(
     datasets.get(id) match {
       case Some(dataset) => {
         val fileIDs = fileList.split(',').map(fid => new UUID(fid)).toList
-        val bagit = play.api.Play.configuration.getBoolean("downloadDatasetBagit").getOrElse(true)
+        val bagit = play.api.Play.configuration.getBoolean("downloadDatasetBagIt").getOrElse(true)
         val baseURL = controllers.routes.Datasets.dataset(id).absoluteURL(https(request))
 
         // Increment download count for each file
@@ -2892,7 +2892,7 @@ class  Datasets @Inject()(
     implicit val user = request.user
     datasets.get(id) match {
       case Some(dataset) => {
-        val bagit = play.api.Play.configuration.getBoolean("downloadDatasetBagit").getOrElse(true)
+        val bagit = play.api.Play.configuration.getBoolean("downloadDatasetBagIt").getOrElse(true)
         val baseURL = controllers.routes.Datasets.dataset(id).absoluteURL(https(request))
 
 

--- a/app/api/Selected.scala
+++ b/app/api/Selected.scala
@@ -109,7 +109,7 @@ class Selected @Inject()(selections: SelectionService,
     Logger.debug("Requesting Selected.downloadAll")
     request.user match {
       case Some(user) => {
-        val bagit = play.api.Play.configuration.getBoolean("downloadDatasetBagit").getOrElse(true)
+        val bagit = play.api.Play.configuration.getBoolean("downloadDatasetBagIt").getOrElse(true)
         val selected = selections.get(user.email.get)
         Ok.chunked(enumeratorFromSelected(selected,1024*1024,bagit,Some(user))).withHeaders(
           "Content-Type" -> "application/zip",

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -477,7 +477,7 @@ addDatasetToCollectionSpace=false
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Whether or not collections or datasets download in bagit format
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-downloadCollectionBagit = true
+downloadCollectionBagIt = true
 downloadDatasetBagIt = false
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Description

The configuration file used downloadDatasetBag**I**t and downloadCollectionBag**i**t, but the code was using downloadDatasetBag**i**t and downloadCollectionBag**i**t. Now all use Bag**I**t.

This does mean that the default behavior now will switch from downloading BagIt datasets to download non BagIt datasets.


## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [X] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [X] I have updated the CHANGELOG.md.
- [ ] I have signed the CLA
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
