### PR TITLE
don't show event stream even when logged in (fixes #280)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - conf file and code had incosistent spelling of BagIt. Now all have capital B and I.
+- when event stream is disabled don't show for logged in user [#280](https://github.com/clowder-framework/clowder/issues/280)
 
 ## 1.19.5 - 2022-01-21
 

--- a/app/views/eventsList.scala.html
+++ b/app/views/eventsList.scala.html
@@ -1,6 +1,7 @@
 @(newsfeed: List[models.Event])(implicit user: Option[models.User])
 @import _root_.util.Formatters
 @import play.api.i18n.Messages
+@import play.api.Play.current
 @for(event <- newsfeed) {
   <div class="panel panel-default">
     <div class="panel-body">
@@ -27,18 +28,25 @@
 }
 <script>
   $(document).ready(function() {
-    // the default number of event index. means there is no event for this user.
-    if(eventCount === 3){
-      @if( newsfeed.size < 1) {
-      $("#moreeventbutton").replaceWith("<p>You can follow <a href=@routes.Users.getUsers()>@Messages("users.title")</a>, <a href=@routes.Spaces.list("")>@Messages("spaces.title")</a>,"
-              + " <a href=@routes.Datasets.list("")>@Messages("datasets.title")</a> and <a href=@routes.Collections.list("")>@Messages("collections.title")</a>."
-              + " Any updates on your followed instances will show here.</p>");
-      } else  {
-      @if( newsfeed.size < 20) { $("#moreeventbutton").replaceWith("<p>No more events.</p>");}
-      }
+    @if(play.Play.application().configuration().getBoolean("clowder.disable.events", false)) {
+      $("#moreeventbutton").replaceWith("<p>Event stream disabled.</p>");
     } else {
-      @if( newsfeed.size < 10) { $("#moreeventbutton").replaceWith("<p>No more events.</p>");}
+      // the default number of event index. means there is no event for this user.
+      if (eventCount === 3) {
+        @if( newsfeed.size < 1) {
+          $("#moreeventbutton").replaceWith("<p>You can follow <a href=@routes.Users.getUsers()>@Messages("users.title")</a>, <a href=@routes.Spaces.list("")>@Messages("spaces.title")</a>,"
+                  + " <a href=@routes.Datasets.list("")>@Messages("datasets.title")</a> and <a href=@routes.Collections.list("")>@Messages("collections.title")</a>."
+                  + " Any updates on your followed instances will show here.</p>");
+        } else  {
+          @if( newsfeed.size < 20) {
+            $("#moreeventbutton").replaceWith("<p>No more events.</p>");
+          }
+        }
+      } else {
+        @if( newsfeed.size < 10) {
+          $("#moreeventbutton").replaceWith("<p>No more events.</p>");
+        }
+      }
     }
-
   });
 </script>


### PR DESCRIPTION
when the user is logged in, it still showed the event stream. This now disables event stream

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [X] When possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [X] I have updated the CHANGELOG.md.
- [ ] I have signed the CLA
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
