### PR TITLE
Release/1.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+## 1.20.0 - 2022-02-07
 
 ### Fixed
 - conf file and code had incosistent spelling of BagIt. Now all have capital B and I.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+- conf file and code had incosistent spelling of BagIt. Now all have capital B and I.
+
 ## 1.19.5 - 2022-01-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - conf file and code had incosistent spelling of BagIt. Now all have capital B and I.
 
+### Changed
+- download of dataset/collection now has optional parameter bagit (default false) to download items in bagit format.
+
 ## 1.19.5 - 2022-01-21
 
 ### Fixed

--- a/app/Iterators/DatasetsInCollectionIterator.scala
+++ b/app/Iterators/DatasetsInCollectionIterator.scala
@@ -11,7 +11,7 @@ import scala.collection.mutable.ListBuffer
 
 //this is used to download the datasets in a collection
 //it creates an iterator for each dataset in the collection
-class DatasetsInCollectionIterator(pathToFolder : String, collection : models.Collection, zip : ZipOutputStream, md5Files : scala.collection.mutable.HashMap[String, MessageDigest], user : Option[User],
+class DatasetsInCollectionIterator(pathToFolder : String, collection : models.Collection, zip : ZipOutputStream, bagit: Boolean, md5Files : scala.collection.mutable.HashMap[String, MessageDigest], user : Option[User],
                                   datasets : DatasetService, files : FileService, folders : FolderService, metadataService : MetadataService,
                                    spaces : SpaceService) extends Iterator[Option[InputStream]] {
 
@@ -36,8 +36,7 @@ class DatasetsInCollectionIterator(pathToFolder : String, collection : models.Co
   }
 
   var currentDatasetIterator : Option[DatasetIterator]  = if (numDatasets > 0){
-
-    Some(new DatasetIterator(pathToFolder+"/"+currentDataset.get.name,currentDataset.get, zip, md5Files,
+    Some(new DatasetIterator(pathToFolder+"/"+currentDataset.get.name,currentDataset.get, zip, bagit, md5Files,
     folders, files,metadataService,datasets,spaces))
   } else {
     None
@@ -56,7 +55,7 @@ class DatasetsInCollectionIterator(pathToFolder : String, collection : models.Co
             currentDataset = Some(datasetsInCollection(datasetCount))
             currentDataset match {
               case Some(cd) => {
-                currentDatasetIterator = Some(new DatasetIterator(pathToFolder+"/"+cd.name,cd, zip, md5Files,
+                currentDatasetIterator = Some(new DatasetIterator(pathToFolder+"/"+cd.name,cd, zip, bagit, md5Files,
                   folders, files,metadataService,datasets,spaces))
                 true
               }

--- a/app/Iterators/FileIterator.scala
+++ b/app/Iterators/FileIterator.scala
@@ -11,7 +11,7 @@ import util.JSONLD
 
 //this is used for file downloads
 //called by the dataset interator
-class FileIterator (pathToFile : String, file : models.File,zip : ZipOutputStream, md5Files :scala.collection.mutable.HashMap[String, MessageDigest], files : FileService, folders : FolderService , metadataService : MetadataService) extends Iterator[Option[InputStream]] {
+class FileIterator (pathToFile : String, file : models.File, bagit: Boolean, zip : ZipOutputStream, md5Files :scala.collection.mutable.HashMap[String, MessageDigest], files : FileService, folders : FolderService , metadataService : MetadataService) extends Iterator[Option[InputStream]] {
 
   def getFileInfoAsJson(file : models.File) : JsValue = {
     val rightsHolder = {
@@ -54,7 +54,7 @@ class FileIterator (pathToFile : String, file : models.File,zip : ZipOutputStrea
     Some(new ByteArrayInputStream(s.getBytes("UTF-8")))
   }
 
-  var file_type : Int = 0
+  var file_type : Int = if (bagit) 0 else 2
   var is : Option[InputStream] = None
   def hasNext() = {
     if ( file_type < 3){

--- a/app/Iterators/RootCollectionIterator.scala
+++ b/app/Iterators/RootCollectionIterator.scala
@@ -17,11 +17,11 @@ import scala.collection.mutable.ListBuffer
 class RootCollectionIterator(pathToFolder : String, root_collection : models.Collection,zip : ZipOutputStream,
                              md5Files : scala.collection.mutable.HashMap[String, MessageDigest],
                              md5Bag : scala.collection.mutable.HashMap[String, MessageDigest],
-                             user : Option[User],totalBytes : Long,bagit : Boolean,
+                             user : Option[User],totalBytes : Long, bagit : Boolean,
                              collections: CollectionService, datasets : DatasetService, files : FileService, folders : FolderService, metadataService : MetadataService,
                              spaces : SpaceService) extends Iterator[Option[InputStream]] {
 
-  val datasetIterator = new DatasetsInCollectionIterator(root_collection.name,root_collection,zip,md5Files,user,
+  val datasetIterator = new DatasetsInCollectionIterator(root_collection.name,root_collection,zip,bagit, md5Files,user,
     datasets,files,folders,metadataService,spaces)
 
   var currentCollectionIterator : Option[CollectionIterator] = None
@@ -34,7 +34,7 @@ class RootCollectionIterator(pathToFolder : String, root_collection : models.Col
   var numCollections = child_collections.size
 
   var bytesSoFar : Long  = 0L
-  var file_type = 0
+  var file_type = if (bagit) 0 else 2
 
 
   private def addCollectionInfoToZip(folderName: String, collection: models.Collection, zip: ZipOutputStream): Option[InputStream] = {
@@ -107,9 +107,9 @@ class RootCollectionIterator(pathToFolder : String, root_collection : models.Col
         true
       } else if (numCollections > 0){
 
-        currentCollectionIterator = Some(new CollectionIterator(pathToFolder+"/"+child_collections(collectionCount).name, child_collections(collectionCount),zip,md5Files,user,
-          collections,datasets,files,
-          folders,metadataService,spaces))
+        currentCollectionIterator = Some(new CollectionIterator(pathToFolder+"/"+child_collections(collectionCount).name,
+          child_collections(collectionCount), zip, md5Files, user, bagit,
+          collections, datasets,files, folders, metadataService, spaces))
         file_type +=1
         true
       } else if (bagit){
@@ -127,7 +127,7 @@ class RootCollectionIterator(pathToFolder : String, root_collection : models.Col
           } else if (collectionCount < numCollections -2){
             collectionCount+=1
             currentCollectionIterator = Some(new CollectionIterator(pathToFolder+"/"+child_collections(collectionCount).name, child_collections(collectionCount),zip,md5Files,user,
-              collections,datasets,files,
+              bagit, collections,datasets,files,
               folders,metadataService,spaces))
             true
           } else {

--- a/app/Iterators/SelectedIterator.scala
+++ b/app/Iterators/SelectedIterator.scala
@@ -21,7 +21,7 @@ class SelectedIterator(pathToFolder : String, selected : List[Dataset], zip : Zi
 
   var datasetCount = 0
   var currDs = selected(datasetCount)
-  var datasetIterator = new DatasetIterator(pathToFolder+"/"+currDs.name, currDs, zip, md5Files, folders, files,
+  var datasetIterator = new DatasetIterator(pathToFolder+"/"+currDs.name, currDs, zip, bagit, md5Files, folders, files,
     metadataService,datasets,spaces)
   var file_type = 0
 
@@ -54,7 +54,7 @@ class SelectedIterator(pathToFolder : String, selected : List[Dataset], zip : Zi
       } else if (selected.length > datasetCount+1){
         datasetCount += 1
         currDs = selected(datasetCount)
-        datasetIterator = new DatasetIterator(pathToFolder+"/"+currDs.name,currDs,zip,md5Files,folders,files,
+        datasetIterator = new DatasetIterator(pathToFolder+"/"+currDs.name,currDs,zip,bagit, md5Files,folders,files,
           metadataService,datasets,spaces)
         true
       } else if (bagit) {

--- a/app/api/Collections.scala
+++ b/app/api/Collections.scala
@@ -805,7 +805,7 @@ class Collections @Inject() (datasets: DatasetService,
     implicit val user = request.user
     collections.get(id) match {
       case Some(collection) => {
-        val bagit = play.api.Play.configuration.getBoolean("downloadCollectionBagit").getOrElse(true)
+        val bagit = play.api.Play.configuration.getBoolean("downloadCollectionBagIt").getOrElse(true)
         // Use custom enumerator to create the zip file on the fly
         // Use a 1MB in memory byte array
         Ok.chunked(enumeratorFromCollection(collection,1024*1024, compression,bagit,user)).withHeaders(

--- a/app/api/Datasets.scala
+++ b/app/api/Datasets.scala
@@ -2838,7 +2838,7 @@ class  Datasets @Inject()(
     implicit val user = request.user
     datasets.get(id) match {
       case Some(dataset) => {
-        val bagit = play.api.Play.configuration.getBoolean("downloadDatasetBagit").getOrElse(true)
+        val bagit = play.api.Play.configuration.getBoolean("downloadDatasetBagIt").getOrElse(true)
         val baseURL = controllers.routes.Datasets.dataset(id).absoluteURL(https(request))
 
         // Increment download count if tracking is enabled
@@ -2867,7 +2867,7 @@ class  Datasets @Inject()(
     datasets.get(id) match {
       case Some(dataset) => {
         val fileIDs = fileList.split(',').map(fid => new UUID(fid)).toList
-        val bagit = play.api.Play.configuration.getBoolean("downloadDatasetBagit").getOrElse(true)
+        val bagit = play.api.Play.configuration.getBoolean("downloadDatasetBagIt").getOrElse(true)
         val baseURL = controllers.routes.Datasets.dataset(id).absoluteURL(https(request))
 
         // Increment download count for each file
@@ -2892,7 +2892,7 @@ class  Datasets @Inject()(
     implicit val user = request.user
     datasets.get(id) match {
       case Some(dataset) => {
-        val bagit = play.api.Play.configuration.getBoolean("downloadDatasetBagit").getOrElse(true)
+        val bagit = play.api.Play.configuration.getBoolean("downloadDatasetBagIt").getOrElse(true)
         val baseURL = controllers.routes.Datasets.dataset(id).absoluteURL(https(request))
 
 

--- a/app/api/Datasets.scala
+++ b/app/api/Datasets.scala
@@ -2369,7 +2369,6 @@ class  Datasets @Inject()(
     * @param dataset dataset from which to get teh files
     * @param chunkSize chunk size in memory in which to buffer the stream
     * @param compression java built in compression value. Use 0 for no compression.
-    * @param bagit whether or not to include bagit structures in zip
    *  @param baseURL the root Clowder URL for metadata files, from original request
     * @param user an optional user to include in metadata
     * @param fileIDs a list of UUIDs of files in the dataset to include (i.e. marked file downloads)
@@ -2377,12 +2376,12 @@ class  Datasets @Inject()(
     * @return Enumerator to produce array of bytes from a zipped stream containing the bytes of each file
     *         in the dataset
     */
-  def enumeratorFromDataset(dataset: Dataset, chunkSize: Int = 1024 * 8,
-                            compression: Int = Deflater.DEFAULT_COMPRESSION, bagit: Boolean, baseURL: String,
-                            user : Option[User], fileIDs: Option[List[UUID]], folderId: Option[UUID])
-                           (implicit ec: ExecutionContext): Enumerator[Array[Byte]] = {
+  def enumeratorFromDatasetBagIt(dataset: Dataset, chunkSize: Int = 1024 * 8,
+                                 compression: Int = Deflater.DEFAULT_COMPRESSION, baseURL: String,
+                                 user : Option[User], fileIDs: Option[List[UUID]], folderId: Option[UUID])
+                                (implicit ec: ExecutionContext): Enumerator[Array[Byte]] = {
     implicit val pec = ec.prepare()
-    val dataFolder = if (bagit) "data/" else ""
+    val dataFolder = "data/"
     val filenameMap = scala.collection.mutable.Map.empty[UUID, String]
     val inputFiles = scala.collection.mutable.ListBuffer.empty[models.File]
 
@@ -2468,14 +2467,9 @@ class  Datasets @Inject()(
                   is = addMD5Entry(filename, is, md5Files)
                   file_index +=1
                   if (file_index >= inputFiles.size) {
-                    if (bagit) {
-                      file_index = 0
-                      level = "bag"
-                      file_type = "bagit.txt"
-                    } else {
-                      level = "done"
-                      file_type = "none"
-                    }
+                    file_index = 0
+                    level = "bag"
+                    file_type = "bagit.txt"
                   }
                 }
                 case ("bag", "bagit.txt") => {
@@ -2539,6 +2533,99 @@ class  Datasets @Inject()(
         case None => Future.successful(None)
       }
     })(pec)
+  }
+
+  /**
+   * Enumerator to loop over all files in a dataset and return chunks for the result zip file that will be
+   * streamed to the client. The zip files are streamed and not stored on disk.
+   *
+   * @param dataset dataset from which to get teh files
+   * @param chunkSize chunk size in memory in which to buffer the stream
+   * @param compression java built in compression value. Use 0 for no compression.
+   * @param baseURL the root Clowder URL for metadata files, from original request
+   * @param user an optional user to include in metadata
+   * @param fileIDs a list of UUIDs of files in the dataset to include (i.e. marked file downloads)
+   * @param folderId a folder UUID in the dataset to include (i.e. folder download)
+   * @return Enumerator to produce array of bytes from a zipped stream containing the bytes of each file
+   *         in the dataset
+   */
+  def enumeratorFromDatasetFiles(dataset: Dataset, chunkSize: Int = 1024 * 8,
+                                 compression: Int = Deflater.DEFAULT_COMPRESSION, baseURL: String,
+                                 user : Option[User], fileIDs: Option[List[UUID]], folderId: Option[UUID])
+                                (implicit ec: ExecutionContext): Enumerator[Array[Byte]] = {
+    implicit val pec = ec.prepare()
+    val dataFolder = ""
+    val filenameMap = scala.collection.mutable.Map.empty[UUID, String]
+    val inputFiles = scala.collection.mutable.ListBuffer.empty[models.File]
+
+    // Get list of all files and folder in dataset and enforce unique names
+    fileIDs match {
+      case Some(fids) => {
+        Logger.info("Downloading only some files")
+        Logger.info(fids.toString)
+        listFilesInFolder(fids, List.empty, dataFolder, filenameMap, inputFiles)
+      }
+      case None => {
+        folderId match {
+          case Some(fid) => listFilesInFolder(List.empty, List(fid), dataFolder, filenameMap, inputFiles)
+          case None => listFilesInFolder(dataset.files, dataset.folders, dataFolder, filenameMap, inputFiles)
+        }
+      }
+    }
+
+    // create the zipfile
+    val byteArrayOutputStream = new ByteArrayOutputStream(chunkSize)
+    val zip = new ZipOutputStream(byteArrayOutputStream)
+    zip.setLevel(compression)
+
+    var file_index = 0
+    val buffer = new Array[Byte](chunkSize)
+    var is: Option[InputStream] = None
+
+    Enumerator.generateM({
+      val bytesRead = is match {
+        case Some(inputStream: InputStream) => {
+          val bytesRead = scala.concurrent.blocking {
+            inputStream.read(buffer)
+          }
+          if (bytesRead == -1) {
+            // finished individual file
+            zip.closeEntry()
+            inputStream.close()
+          }
+          bytesRead
+        }
+        case None => -1
+      }
+
+      val chunk = if (bytesRead == -1) {
+        if (file_index == -1) {
+          None
+        } else if (file_index < inputFiles.length) {
+          val filename = filenameMap(inputFiles(file_index).id)
+          is = addFileToZip(filename, inputFiles(file_index), zip)
+          file_index += 1
+          val result = Some(byteArrayOutputStream.toByteArray)
+          byteArrayOutputStream.reset()
+          result
+        } else {
+          zip.close()
+          val result = Some(byteArrayOutputStream.toByteArray)
+          byteArrayOutputStream.reset()
+          is = None
+          file_index = -1
+          result
+        }
+      } else {
+        zip.write(buffer, 0, bytesRead)
+        val result = Some(byteArrayOutputStream.toByteArray)
+        byteArrayOutputStream.reset()
+        result
+      }
+
+      Future.successful(chunk)
+    })(pec)
+
   }
 
   private def addMD5Entry(name: String, is: Option[InputStream], md5HashMap: scala.collection.mutable.HashMap[String, MessageDigest]) = {
@@ -2834,11 +2921,10 @@ class  Datasets @Inject()(
     Some(new ByteArrayInputStream(s.getBytes("UTF-8")))
   }
 
-  def download(id: UUID, compression: Int, tracking: Boolean) = PermissionAction(Permission.DownloadFiles, Some(ResourceRef(ResourceRef.dataset, id))) { implicit request =>
+  def download(id: UUID, bagit: Boolean, compression: Int, tracking: Boolean) = PermissionAction(Permission.DownloadFiles, Some(ResourceRef(ResourceRef.dataset, id))) { implicit request =>
     implicit val user = request.user
     datasets.get(id) match {
       case Some(dataset) => {
-        val bagit = play.api.Play.configuration.getBoolean("downloadDatasetBagIt").getOrElse(true)
         val baseURL = controllers.routes.Datasets.dataset(id).absoluteURL(https(request))
 
         // Increment download count if tracking is enabled
@@ -2849,7 +2935,13 @@ class  Datasets @Inject()(
 
         // Use custom enumerator to create the zip file on the fly
         // Use a 1MB in memory byte array
-        Ok.chunked(enumeratorFromDataset(dataset,1024*1024, compression, bagit, baseURL, user, None, None)).withHeaders(
+        val enumerator = if (bagit) {
+          enumeratorFromDatasetBagIt(dataset,1024*1024, -1, baseURL, user, None, None)
+        } else {
+          enumeratorFromDatasetFiles(dataset,1024*1024, -1, baseURL, user, None, None)
+        }
+
+        Ok.chunked(enumerator).withHeaders(
           CONTENT_TYPE -> "application/zip",
           CONTENT_DISPOSITION -> (FileUtils.encodeAttachment(dataset.name+ ".zip", request.headers.get("user-agent").getOrElse("")))
         )
@@ -2862,12 +2954,11 @@ class  Datasets @Inject()(
   }
 
   // Takes dataset ID and a comma-separated string of file UUIDs in the dataset and streams just those files as a zip
-  def downloadPartial(id: UUID, fileList: String) = PermissionAction(Permission.DownloadFiles, Some(ResourceRef(ResourceRef.dataset, id))) { implicit request =>
+  def downloadPartial(id: UUID, fileList: String, bagit: Boolean) = PermissionAction(Permission.DownloadFiles, Some(ResourceRef(ResourceRef.dataset, id))) { implicit request =>
     implicit val user = request.user
     datasets.get(id) match {
       case Some(dataset) => {
         val fileIDs = fileList.split(',').map(fid => new UUID(fid)).toList
-        val bagit = play.api.Play.configuration.getBoolean("downloadDatasetBagIt").getOrElse(true)
         val baseURL = controllers.routes.Datasets.dataset(id).absoluteURL(https(request))
 
         // Increment download count for each file
@@ -2875,7 +2966,12 @@ class  Datasets @Inject()(
 
         // Use custom enumerator to create the zip file on the fly
         // Use a 1MB in memory byte array
-        Ok.chunked(enumeratorFromDataset(dataset,1024*1024, -1, bagit, baseURL, user, Some(fileIDs), None)).withHeaders(
+        val enumerator = if (bagit) {
+          enumeratorFromDatasetBagIt(dataset,1024*1024, -1, baseURL, user, Some(fileIDs), None)
+        } else {
+          enumeratorFromDatasetFiles(dataset,1024*1024, -1, baseURL, user, Some(fileIDs), None)
+        }
+        Ok.chunked(enumerator).withHeaders(
           CONTENT_TYPE -> "application/zip",
           CONTENT_DISPOSITION -> (FileUtils.encodeAttachment(dataset.name+ " (Partial).zip", request.headers.get("user-agent").getOrElse("")))
         )
@@ -2888,22 +2984,26 @@ class  Datasets @Inject()(
   }
 
   // Takes dataset ID and a folder ID in that dataset and streams just that folder and sub-folders as a zip
-  def downloadFolder(id: UUID, folderId: UUID) = PermissionAction(Permission.DownloadFiles, Some(ResourceRef(ResourceRef.dataset, id))) { implicit request =>
+  def downloadFolder(id: UUID, folderId: UUID, bagit: Boolean) = PermissionAction(Permission.DownloadFiles, Some(ResourceRef(ResourceRef.dataset, id))) { implicit request =>
     implicit val user = request.user
     datasets.get(id) match {
       case Some(dataset) => {
-        val bagit = play.api.Play.configuration.getBoolean("downloadDatasetBagIt").getOrElse(true)
         val baseURL = controllers.routes.Datasets.dataset(id).absoluteURL(https(request))
-
 
         // Increment download count for each file in folder
         folders.get(folderId) match {
           case Some(fo) => {
             fo.files.foreach(fid => files.incrementDownloads(fid, user))
 
+            val enumerator = if (bagit) {
+              enumeratorFromDatasetBagIt(dataset, 1024*1024, -1, baseURL, user, None, Some(folderId))
+            } else {
+              enumeratorFromDatasetFiles(dataset, 1024*1024, -1, baseURL, user, None, Some(folderId))
+            }
+
             // Use custom enumerator to create the zip file on the fly
             // Use a 1MB in memory byte array
-            Ok.chunked(enumeratorFromDataset(dataset,1024*1024, -1, bagit, baseURL, user, None, Some(folderId))).withHeaders(
+            Ok.chunked(enumerator).withHeaders(
               CONTENT_TYPE -> "application/zip",
               CONTENT_DISPOSITION -> (FileUtils.encodeAttachment(dataset.name+ " ("+fo.name+" Folder).zip", request.headers.get("user-agent").getOrElse("")))
             )

--- a/app/api/Selected.scala
+++ b/app/api/Selected.scala
@@ -109,7 +109,7 @@ class Selected @Inject()(selections: SelectionService,
     Logger.debug("Requesting Selected.downloadAll")
     request.user match {
       case Some(user) => {
-        val bagit = play.api.Play.configuration.getBoolean("downloadDatasetBagit").getOrElse(true)
+        val bagit = play.api.Play.configuration.getBoolean("downloadDatasetBagIt").getOrElse(true)
         val selected = selections.get(user.email.get)
         Ok.chunked(enumeratorFromSelected(selected,1024*1024,bagit,Some(user))).withHeaders(
           "Content-Type" -> "application/zip",

--- a/app/views/dataset.scala.html
+++ b/app/views/dataset.scala.html
@@ -190,7 +190,7 @@
                     }
                     @if(showDownload && Permission.checkPermission(Permission.DownloadFiles, ResourceRef(ResourceRef.dataset, dataset.id)) && !dataset.trash) {
                         <a id='download-url' href="#"
-                            onclick="window.open(jsRoutes.api.Datasets.download('@dataset.id', -1, true).url, '_blank');"
+                            onclick="window.open(jsRoutes.api.Datasets.download('@dataset.id', false, -1, true).url, '_blank');"
                             class="btn btn-link" title="Download All Files as Zip" role="button">
                             <span class="glyphicon glyphicon-download-alt"></span>
                             Download All Files

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -477,7 +477,7 @@ addDatasetToCollectionSpace=false
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Whether or not collections or datasets download in bagit format
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-downloadCollectionBagit = true
+downloadCollectionBagIt = true
 downloadDatasetBagIt = false
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -475,12 +475,6 @@ clowder.tagLength=100
 addDatasetToCollectionSpace=false
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Whether or not collections or datasets download in bagit format
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-downloadCollectionBagIt = true
-downloadDatasetBagIt = false
-
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Polyglot
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #url to get all outputs for given input

--- a/conf/routes
+++ b/conf/routes
@@ -516,7 +516,7 @@ POST           /api/collections                                                 
 GET            /api/collections/rootCollections                                         @api.Collections.getRootCollections
 GET            /api/collections/topLevelCollections                                     @api.Collections.getTopLevelCollections
 GET            /api/collections/allCollections                                          @api.Collections.getAllCollections(limit : Int ?= 0, showAll: Boolean ?=false)
-GET            /api/collections/:id/download                                            @api.Collections.download(id: UUID, compression: Int ?= -1)
+GET            /api/collections/:id/download                                            @api.Collections.download(id: UUID, compression: Int ?= -1, bagit: Boolean ?= false)
 GET            /api/collections/listTrash                                               @api.Collections.listCollectionsInTrash(limit : Int ?= 12)
 DELETE         /api/collections/emptyTrash                                              @api.Collections.emptyTrash()
 DELETE         /api/collections/clearOldCollectionsTrash                                @api.Collections.clearOldCollectionsTrash(days : Int ?= 30)
@@ -592,9 +592,9 @@ GET            /api/datasets/:id/listAllFiles                                   
 GET            /api/datasets/:id/files                                                  @api.Datasets.datasetAllFilesList(id: UUID, max: Int ?= -1)
 POST           /api/datasets/:id/files                                                  @api.Datasets.uploadToDatasetFile(id: UUID)
 POST           /api/datasets/:id/urls                                                   @api.Datasets.uploadToDatasetJSON(id: UUID)
-GET            /api/datasets/:id/download                                               @api.Datasets.download(id: UUID, compression: Int ?= -1, tracking: Boolean ?= true)
-GET            /api/datasets/:id/downloadPartial                                        @api.Datasets.downloadPartial(id: UUID, fileList: String)
-GET            /api/datasets/:id/downloadFolder                                         @api.Datasets.downloadFolder(id: UUID, folderId: UUID)
+GET            /api/datasets/:id/download                                               @api.Datasets.download(id: UUID, bagit: Boolean ?= false, compression: Int ?= -1, tracking: Boolean ?= true)
+GET            /api/datasets/:id/downloadPartial                                        @api.Datasets.downloadPartial(id: UUID, fileList: String, bagit: Boolean ?= false)
+GET            /api/datasets/:id/downloadFolder                                         @api.Datasets.downloadFolder(id: UUID, folderId: UUID, bagit: Boolean ?= false)
 POST           /api/datasets/:id/comment                                                @api.Datasets.comment(id: UUID)
 POST           /api/datasets/:id/reindex                                                @api.Datasets.reindex(id:UUID, recursive: Boolean ?= true)
 POST           /api/datasets/:id/follow                                                 @api.Datasets.follow(id: UUID)

--- a/doc/src/sphinx/conf.py
+++ b/doc/src/sphinx/conf.py
@@ -22,7 +22,7 @@ copyright = '2019, University of Illinois at Urbana-Champaign'
 author = 'Luigi Marini'
 
 # The full version, including alpha/beta/rc tags
-release = '1.19.5'
+release = '1.20.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -13,7 +13,7 @@ import NativePackagerKeys._
 object ApplicationBuild extends Build {
 
   val appName = "clowder"
-  val version = "1.19.5"
+  val version = "1.20.0"
   val jvm = "1.7"
 
   def appVersion: String = {

--- a/public/swagger.yml
+++ b/public/swagger.yml
@@ -9,7 +9,7 @@ info:
     Clowder is a customizable and scalable data management system to support any
     data format and multiple research domains. It is under active development
     and deployed for a variety of research projects.
-  version: 1.19.5
+  version: 1.20.0
   termsOfService: https://clowder.ncsa.illinois.edu/clowder/tos
   contact:
     name: Clowder


### PR DESCRIPTION
Release 1.20.0

## Fixed
- [x] conf file and code had incosistent spelling of BagIt. Now all have capital B and I.
- [ ] when event stream is disabled don't show for logged in user [#280](https://github.com/clowder-framework/clowder/issues/280)
- [ ] three.js is no longer associated with application/octet-stream, now with models [#305](https://github.com/clowder-framework/clowder/issues/305)

## Changed
- [x] download of dataset/collection now has optional parameter bagit (default false) to download items in bagit format.

draft until last 2 PR are merged.