### PR TITLE
Include 'when' parameter on sub-collection select

### DIFF
--- a/app/views/collections/parentAllocation.scala.html
+++ b/app/views/collections/parentAllocation.scala.html
@@ -76,7 +76,7 @@
         allowClear: true,
         ajax: {
             url: function(params) {
-                return jsRoutes.api.Collections.listPossibleParents( '@resourceId', params.term,null, 5).url;
+                return jsRoutes.api.Collections.listPossibleParents(null, '@resourceId', params.term, null, 5).url;
             },
             data: function(params) {
                 return { title: params.term };


### PR DESCRIPTION
Fixes bug where "Select a Collection" Parent Collection dropdown on Collection page was not working due to missing parameter (#343)

This can be a hotfix if others agree.