### PR TITLE
Build and run core using eclipse-temurin:8. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # BUILD CLOWDER DIST
 # ----------------------------------------------------------------------
-FROM openjdk:8-jdk-bullseye as clowder-build
+FROM eclipse-temurin:8-jdk as clowder-build
 
 ARG BRANCH="unknown"
 ARG VERSION="unknown"
@@ -40,7 +40,7 @@ RUN rm -rf target/universal/clowder-*.zip clowder clowder-* \
 # ----------------------------------------------------------------------
 # BUILD CLOWDER
 # ----------------------------------------------------------------------
-FROM openjdk:8-jre-bullseye as clowder-runtime
+FROM eclipse-temurin:8-jre as clowder-runtime
 
 # environemnt variables
 ARG BRANCH="unknown"


### PR DESCRIPTION
Seems to build fine, but throws error at run time:

```home/clowder/clowder.sh: line 4: /home/clowder/bin/clowder: No such file or directory. Looks like when unzipping some files are missing.```

This to try and fix issue with TLS not being set to 1.2 by default. #430 