### PR TITLE
remove file from folders if we are moving it into the same dataset

### DIFF
--- a/app/api/Datasets.scala
+++ b/app/api/Datasets.scala
@@ -716,7 +716,15 @@ class  Datasets @Inject()(
       }
       Logger.debug("----- Adding file to dataset completed")
     } else {
+        val foldersContainingFile = folders.findByFileId(file.id).sortBy(_.name)
         Logger.debug("File was already in dataset.")
+        val foldersContainingFile = folders.findByFileId(file.id).sortBy(_.name)
+        Logger.debug("Remove file from folders in dataset")
+        folders.get(foldersContainingFile).foreach(folder => {
+          if (folder.parentDatasetId == dsId){
+            folders.removeFile(folder.id, fileId)
+          }
+        })
     }
   }
 


### PR DESCRIPTION
The new expected behavior is that if you move a file to the same dataset that it is already inside, it should remove it from any folders in the dataset. This fixes a duplicate file view bug that happened when using the api route to move files. 