### PR TITLE
adding creator to space json returned, adding route for users in space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.22.2 - 2025-09-10
+
+### Added
+- Space api routes now return users and creator.
+
 ## 1.22.1 - 2023-11-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 1.22.2 - 2025-09-10
+## [Unreleased]
 
 ### Added
 - Space api routes now return users and creator.

--- a/app/api/Spaces.scala
+++ b/app/api/Spaces.scala
@@ -167,6 +167,7 @@ class Spaces @Inject()(spaces: SpaceService,
     toJson(Map("id" -> space.id.stringify,
       "name" -> space.name,
       "description" -> space.description,
+      "creator" -> space.creator.stringify,
       "created" -> space.created.toString))
   }
 

--- a/app/api/Spaces.scala
+++ b/app/api/Spaces.scala
@@ -93,9 +93,7 @@ class Spaces @Inject()(spaces: SpaceService,
   def getUsers(id: UUID) = PermissionAction(Permission.ViewSpace, Some(ResourceRef(ResourceRef.space, id))) { implicit request =>
     spaces.get(id) match {
       case Some(space) =>
-
         val usersInSpace = spaces.getUsersInSpace(space.id, None)
-
         Ok(toJson(usersInSpace.map(userToJson)))
       case None => {
         NotFound("Space not found")

--- a/conf/routes
+++ b/conf/routes
@@ -488,6 +488,7 @@ GET            /api/files/:three_d_file_id/:filename                            
 GET            /api/spaces                                                              @api.Spaces.list(when: Option[String] ?= None, title: Option[String] ?= None, date: Option[String] ?= None, limit: Int ?= 12)
 GET            /api/spaces/canEdit                                                      @api.Spaces.listCanEdit(when: Option[String] ?= None, title: Option[String] ?= None, date: Option[String] ?= None, limit: Int ?= 12)
 GET            /api/spaces/:id                                                          @api.Spaces.get(id: UUID)
+GET            /api/spaces/:id/users                                                    @api.Spaces.getUsers(id: UUID)
 POST           /api/spaces                                                              @api.Spaces.createSpace()
 DELETE         /api/spaces/:id                                                          @api.Spaces.removeSpace(id: UUID)
 POST           /api/spaces/:spaceId/removeCollection/:collectionId                      @api.Spaces.removeCollection(spaceId: UUID, collectionId: UUID, removeDatasets : Boolean)


### PR DESCRIPTION
Currently the space json does not include the creator for the api routes. I have added it since this will be needed for migrating spaces.